### PR TITLE
fix(seo): repair the paths the Astro to Jigsaw migration left behind

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -139,6 +139,8 @@ Partials take data through the `@include` array: `@include('_partials.icon', ['n
 
 Social cards are `source/og/monica-<locale>.png`, one per language, 1200x630. They are generated from `scripts/og/template.html` by `npm run og`, which drives headless Chrome. The PNGs are committed so a build never depends on a browser being installed. **The template mirrors the hero copy by hand**, so when a hero headline changes in `lang/`, update the template and re-run `npm run og`.
 
+The template is opened over `file://`, outside the build, so it resolves the webfont and the panda mark by relative path from `scripts/og/`. Chrome fails those silently: a missing font falls back to a system sans and a missing mark just leaves a gap, in an image nobody looks at until it is on X. Moving either asset means editing the two URLs in the template, and the way to check is to open the output, not to trust the exit code.
+
 ## Star count
 
 `bootstrap.php` reads `monicahq/monica` from the GitHub API in a `beforeBuild` listener and writes `starCount` into config, so templates use `$page->starCount`. It floors to the nearest thousand, so 24,956 renders as `24k+`. **Floor, never round**: the `+` promises at least that many.

--- a/scripts/og/generate.sh
+++ b/scripts/og/generate.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Renders the social sharing images into public/og/, one per locale, at
+# Renders the social sharing images into source/og/, one per locale, at
 # 1200x630. Run it after editing scripts/og/template.html or after changing the
 # hero copy it mirrors:
 #
@@ -22,7 +22,7 @@ fi
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 TEMPLATE="$ROOT/scripts/og/template.html"
-OUT_DIR="$ROOT/public/og"
+OUT_DIR="$ROOT/source/og"
 
 mkdir -p "$OUT_DIR"
 
@@ -50,4 +50,4 @@ for locale in en fr de es; do
   echo "  $(basename "$out")  $(du -h "$out" | cut -f1)"
 done
 
-echo "Wrote $(ls -1 "$OUT_DIR"/*.png | wc -l | tr -d ' ') images to public/og/"
+echo "Wrote $(ls -1 "$OUT_DIR"/*.png | wc -l | tr -d ' ') images to source/og/"

--- a/scripts/og/template.html
+++ b/scripts/og/template.html
@@ -4,14 +4,19 @@
     <meta charset="utf-8" />
     <title>Monica social card</title>
     <!--
-      Source for the social sharing images in public/og/. Rendered to PNG by
+      Source for the social sharing images in source/og/. Rendered to PNG by
       scripts/og/generate.sh, one per locale, at 1200x630.
 
       This file is a build artifact generator, not part of the site, so the
       design tokens are written out literally: it is opened over file:// by
       headless Chrome, where Tailwind's @theme block would mean nothing. The
-      values are copied from src/styles/theme.css and must be kept in step
-      with it.
+      values are copied from source/_assets/css/theme.css and must be kept in
+      step with it.
+
+      The webfont and the mark below are resolved by relative path from this
+      directory, not by the build. Chrome renders a missing one silently: the
+      type falls back to a system sans and the mark simply does not appear.
+      Moving either asset means editing the two URLs here.
 
       Design system rules still apply. Flat colour, one-pixel borders, no
       shadow, no gradient, sentence case.
@@ -19,7 +24,7 @@
     <style>
       @font-face {
         font-family: 'Inter';
-        src: url('../../src/assets/fonts/Inter-Variable.woff2') format('woff2');
+        src: url('../../source/_assets/fonts/Inter-Variable.woff2') format('woff2');
         font-weight: 100 900;
         font-style: normal;
       }
@@ -109,7 +114,7 @@
 
   <body>
     <div class="brand">
-      <img src="../../src/assets/monica-panda-mark.jpg" alt="" />
+      <img src="../../source/assets/images/monica-panda-mark.jpg" alt="" />
       <span>Monica</span>
     </div>
 

--- a/source/robots.txt
+++ b/source/robots.txt
@@ -4,4 +4,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://www.monicahq.com/sitemap-index.xml
+Sitemap: https://www.monicahq.com/sitemap.xml


### PR DESCRIPTION
Implements #2 against the current codebase.

## What I found

**#2's content is already here.** The Jigsaw rewrite in #3 carried all of it across, faithfully:

| #2 | Here |
| :--- | :--- |
| `src/components/Seo.astro` | `source/_partials/seo.blade.php` |
| `ogLocales` in `src/i18n/config.ts` | `ogLocales` in `config.php` |
| `meta.imageAlt` in `src/i18n/content/*.ts` | `meta.imageAlt` in `lang/*.php` |
| `@astrojs/sitemap` with `i18n` | `source/sitemap.blade.xml` |
| `public/robots.txt` | `source/robots.txt` |
| `src/pages/404.astro` | `source/404.blade.php` |
| `public/og/monica-*.png` | `source/og/monica-*.png` (byte-identical) |
| `scripts/og/*` | `scripts/og/*` (byte-identical) |

The head renders everything #2 describes: canonical, four reciprocal hreflang plus `x-default`, Open Graph with `language_TERRITORY` locales, the Twitter card, and `Organization` + `WebSite` JSON-LD.

**What did not survive is the paths.** Four Astro-era file locations were copied over unchanged. None of them fails the build, which is why they went unnoticed.

## The four breakages

| File | Was | Effect |
| :--- | :--- | :--- |
| `source/robots.txt` | `Sitemap: …/sitemap-index.xml` | `sitemap-index.xml` is an `@astrojs/sitemap` filename. Jigsaw writes `sitemap.xml`. The one URL robots.txt exists to advertise returned a 404. |
| `scripts/og/generate.sh` | `OUT_DIR="$ROOT/public/og"` | `public/` is the Astro static dir and is gone. The script recreated it and wrote four PNGs where nothing reads them, so `npm run og` could never update the committed cards. |
| `scripts/og/template.html` | `../../src/assets/fonts/Inter-Variable.woff2` | Font fails silently over `file://`. Cards rendered in a system fallback, not Inter. |
| `scripts/og/template.html` | `../../src/assets/monica-panda-mark.jpg` | **The panda mark did not render at all.** |

Plus a comment citing `src/styles/theme.css` as the source of the template's token values.

## The check that proves it

Before the fix, running the generator produced cards with no logo and the wrong typeface. After it, `npm run og` reproduces the four committed PNGs **byte for byte** — `git status` is empty afterwards. That only holds if all three paths are right, so it is a real regression test rather than an eyeball check.

I did not commit regenerated PNGs: they are identical, so there is nothing to commit.

## Verification

- `npm run build` clean. `build_production/robots.txt` names `sitemap.xml`; that file exists, with 8 `<loc>` entries and 40 `xhtml:link` annotations.
- `npm run og` reports four images into `source/og/` and creates no `public/`.
- French page head unchanged: canonical, five hreflang, `og:locale` `fr_FR`, absolute `og:image`, JSON-LD parses to `Organization` + `WebSite` with a resolvable logo URL.
- No `src/assets`, `src/styles`, `public/og` or `sitemap-index` references remain anywhere outside `vendor/` and `node_modules/`.

## Also

`.claude/CLAUDE.md` gains a short note on why this failed quietly: the template is rendered outside the build, over `file://`, so the build cannot catch a broken asset path and Chrome will not complain. The way to verify a card is to open it.

## Not in this PR

No v3-specific social cards, and no change to the template mirroring hero copy by hand. #2 names that as follow-up in its own description; it needs a rendering dependency rather than a path fix.