### PR TITLE
feat: add the pricing page

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -124,6 +124,7 @@ Partials take data through the `@include` array: `@include('_partials.icon', ['n
 | Design tokens to Tailwind           | `source/_assets/css/theme.css`                      |
 | Vendored design system              | `source/_assets/css/design-system/` (do not edit)   |
 | Compiled CSS entry                  | `source/_assets/css/main.css`                       |
+| Compiled JS entry (Alpine)          | `source/_assets/js/app.js`                          |
 | Fonts                               | `source/_assets/fonts/`                             |
 | Images, OG cards, robots.txt        | `source/assets/`, `source/og/`, `source/robots.txt` |
 
@@ -150,7 +151,10 @@ Failures keep the fallback in `config.php` and print a warning rather than break
 ## Other conventions
 
 - **Static by default.** Jigsaw outputs files. Nothing runs server-side in production.
-- **Zero JS unless asked.** The site currently ships none: the FAQ and the language menu are native `<details>`, and Vite has no JS entry point. Adding one is a real decision, so ask first.
+- **Almost no JS, and only where asked.** The site ships one script, `source/_assets/js/app.js`, which starts [Alpine](https://alpinejs.dev) and nothing else. It exists for the pricing page's billing toggle. The FAQ and the language menu are still native `<details>` and must stay that way: reach for Alpine only when a native element genuinely cannot do the job, and ask first.
+- **Anything Alpine touches is server-rendered in its default state first.** Bind with `x-text` wrapped around real content (`<span x-text="plans[period].price">$90</span>`), never an empty element filled in on load. A control that does nothing without Alpine carries `js-only`, which `_layouts/base.blade.php` hides inside a `<noscript>` block, so a reader without JavaScript is not offered a dead button.
+- Alpine state comes from `lang/` through one `json_encode` into `x-data`, so copy never gets hard-coded into an expression. Blade escapes the quotes and the browser decodes them; see `_partials/pricing/plans.blade.php`.
+- Class names inside `x-bind:class` are literal strings in the template, so Tailwind's scanner finds them. Building one by concatenation makes it invisible to the scanner and the class silently vanishes from the stylesheet.
 - **No new dependencies without asking**, Composer or npm.
 - **Marketing copy is the owner's call.** Draft it when asked, but don't rewrite existing headlines, pricing or product claims as a side effect of an unrelated change.
 

--- a/config.php
+++ b/config.php
@@ -60,6 +60,8 @@ return [
         // language. Slugs are still declared per locale, because the next page
         // added will not be.
         'v3' => ['en' => 'v3', 'fr' => 'v3', 'de' => 'v3', 'es' => 'v3'],
+
+        'pricing' => ['en' => 'pricing', 'fr' => 'tarifs', 'de' => 'preise', 'es' => 'precios'],
     ],
 
     // ------------------------------------------------------------------ links
@@ -117,7 +119,25 @@ return [
             throw new Exception("Missing translation [{$key}] for locale [{$locale}].");
         }
 
-        return $replace && is_string($value) ? strtr($value, $replace) : $value;
+        if (! $replace) {
+            return $value;
+        }
+
+        /**
+         * Placeholders are filled at every depth, not just on a bare string.
+         * A FAQ answer is a list of paragraphs and a plan is a nested array, so
+         * substituting only the top level silently shipped a literal ":count"
+         * to the page once already.
+         */
+        $fill = function ($value) use (&$fill, $replace) {
+            if (is_array($value)) {
+                return array_map($fill, $value);
+            }
+
+            return is_string($value) ? strtr($value, $replace) : $value;
+        };
+
+        return $fill($value);
     },
 
     /**

--- a/lang/de.php
+++ b/lang/de.php
@@ -15,6 +15,11 @@ return [
             'description' => "Monica hilft Ihnen, sich an die Menschen zu erinnern, die Ihnen wichtig sind: was in ihrem Leben passiert, wichtige Daten, frühere Gespräche und wann Sie sich wieder melden sollten. Privat, quelloffen, selbst hostbar.",
         ],
 
+        'pricing' => [
+            'title' => "Monica-Preise — ein gehosteter Tarif, oder kostenlos selbst hosten",
+            'description' => "Gehostete Monica kostet 9 USD pro Monat oder 90 USD pro Jahr, mit unbegrenzten Kontakten und ohne Preis pro Kontakt. Oder hosten Sie die quelloffene Anwendung kostenlos auf Ihrer eigenen Infrastruktur.",
+        ],
+
         'v3' => [
             'title' => "Monica v3 — neu gebaut für die nächsten zehn Jahre",
             'description' => "Monica v3 ist ein vollständiger Neubau des quelloffenen persönlichen CRM: Einträge, die Sie selbst gestalten, ein mit allem verbundenes Journal, eine vollständige API und eine echte mobile Erfahrung. Weiterhin quelloffen, jetzt unter MIT-Lizenz. Vor Ende 2026.",
@@ -383,6 +388,205 @@ return [
         'primaryCta' => "Mit Monica beginnen",
         'secondaryCta' => "Monica v3 ansehen",
         'note' => "Quelloffen · Selbst hostbar · Ohne Kreditkarte",
+    ],
+
+    /** Die Seite /preise. Die Preise stammen aus dem Design; hier je Locale ändern. */
+    'pricing' => [
+        'eyebrow' => "Einfache Preise",
+        'title' => "Ein gehosteter Tarif. Keine Preise pro Beziehung.",
+        'lede' => "Nutzen Sie Monica auf unseren Servern zu einem vorhersehbaren Preis, oder hosten Sie sie kostenlos selbst.",
+        'lede2' => "Wir berechnen nichts pro Kontakt, pro Erinnerung, pro wichtigem Geburtstag oder pro Person, die Sie nicht enttäuschen möchten.",
+        'currency' => "Preise in USD",
+        'taxFootnote' => "Die Preise werden in USD angezeigt. Anfallende Steuern werden vor der Zahlung berechnet.",
+
+        'billing' => [
+            'label' => "Abrechnungszeitraum",
+            'yearly' => "Jährlich — 2 Monate geschenkt",
+            'monthly' => "Monatlich",
+        ],
+
+        'hosted' => [
+            'title' => "Gehostete Monica",
+            'body' => "Für alle, die Monica nutzen wollen, ohne einen Server zu pflegen.",
+            'yearlyPrice' => "90 $",
+            'yearlyPeriod' => "USD / Jahr",
+            'yearlyNote' => "Zwei Monate geschenkt bei jährlicher Abrechnung.",
+            'monthlyPrice' => "9 $",
+            'monthlyPeriod' => "USD / Monat",
+            'monthlyNote' => "Monatlich abgerechnet. Wechseln Sie zu jährlich für zwei Freimonate.",
+            'taxNote' => "Je nach Land können Steuern anfallen.",
+            'cta' => "Mit Monica beginnen",
+            'trial' => "30 Tage testen · Während der Testphase keine Kreditkarte nötig",
+            'listTitle' => "Alles, was Sie brauchen, um sich an die Menschen zu erinnern, die zählen:",
+            'items' => [
+                "unbegrenzte Kontakte;",
+                "unbegrenzte Notizen;",
+                "unbegrenzte Erinnerungen;",
+                "unbegrenzte Aktivitäten und Journaleinträge;",
+                "Beziehungsverwaltung;",
+                "eigene Felder und Abschnitte;",
+                "Dateianhänge;",
+                "Datenexport;",
+                "automatische Updates;",
+                "verwaltete Sicherungen;",
+                "E-Mail-Support;",
+                "Zugriff von Telefon, Tablet und Computer;",
+                "alle künftigen gehosteten Funktionen inbegriffen.",
+            ],
+            'aside' => "Kein Aufpreis für eine große Familie.",
+            'footnote' => "Kündigen Sie, wann Sie möchten. Ihre Kontakte werden nicht als Geisel genommen.",
+        ],
+
+        'selfHosted' => [
+            'title' => "Lieber Ihr eigener Server?",
+            'body' => "Monica ist quelloffen und lässt sich auf einer Infrastruktur Ihrer Wahl installieren.",
+            'price' => "0 $",
+            'period' => "von Monica",
+            'aside' => "Ihr Hosting-Anbieter möchte womöglich trotzdem Geld. Den Kapitalismus haben wir noch nicht besiegt.",
+            'cta' => "Anleitung zum Selbst-Hosten ansehen",
+            'sourceCta' => "Quellcode auf GitHub ansehen · :count Sterne",
+            'listTitle' => "Die Anwendung bekommen Sie kostenlos. Sie stellen den Server, die Updates, die Sicherungen, die Überwachung, die Sicherheitspatches und die ruhige Gewissheit, genau zu wissen, wo Ihre Daten liegen.",
+            'items' => [
+                "die vollständige quelloffene Anwendung;",
+                "unbegrenzte Kontakte;",
+                "so viele Nutzerinnen und Nutzer, wie Ihre Infrastruktur trägt;",
+                "volle Kontrolle über Ihre Daten;",
+                "Datenimport und -export;",
+                "Dokumentation der Community;",
+                "Unterstützung durch die Community;",
+                "die Möglichkeit, den Quellcode einzusehen und zu ändern;",
+                "die MIT-Lizenz in Monica v3.",
+            ],
+            'footnote' => "Die selbst gehostete Ausgabe ist keine abgespeckte Demo. Es ist Monica auf Ihrer Infrastruktur.",
+            'footnote2' => "Verwaltete Sicherungen, E-Mail-Versand, Infrastrukturüberwachung und direkter Support gehören zum gehosteten Dienst.",
+        ],
+
+        'compare' => [
+            'title' => "Dieselbe Monica. Eine andere Person ist für den Server zuständig.",
+            'rowHeader' => "Was",
+            'hosted' => "Gehostete Monica",
+            'selfHosted' => "Selbst gehostete Monica",
+            'rows' => [
+                ['label' => "Monica-Software", 'hosted' => "Enthalten", 'selfHosted' => "Enthalten"],
+                ['label' => "Kontakte", 'hosted' => "Unbegrenzt", 'selfHosted' => "Unbegrenzt"],
+                ['label' => "Updates", 'hosted' => "Automatisch", 'selfHosted' => "Sie installieren sie"],
+                ['label' => "Sicherungen", 'hosted' => "Von Monica verwaltet", 'selfHosted' => "Sie verwalten sie"],
+                ['label' => "Serverwartung", 'hosted' => "Von Monica verwaltet", 'selfHosted' => "Sie übernehmen sie"],
+                ['label' => "Speicherort der Daten", 'hosted' => "Monica-Infrastruktur", 'selfHosted' => "Ihre Infrastruktur"],
+                ['label' => "Erforderliches technisches Wissen", 'hosted' => "Keines", 'selfHosted' => "Etwas"],
+                ['label' => "Support", 'hosted' => "E-Mail-Support", 'selfHosted' => "Community-Support"],
+                ['label' => "Kosten", 'hosted' => "Monats- oder Jahresabo", 'selfHosted' => "Kostenlose Software plus Hosting-Kosten"],
+                ['label' => "Am besten für", 'hosted' => "Menschen, die wollen, dass Monica läuft", 'selfHosted' => "Menschen, die Server mögen oder müssen"],
+            ],
+        ],
+
+        'whyPay' => [
+            'title' => "Warum zahlen, wenn Monica quelloffen ist?",
+            'body' => "Quelloffen heißt, dass Sie Monica betreiben, einsehen, ändern und zu ihr beitragen können. Server, Sicherungen, E-Mail-Versand, Sicherheitsarbeit und Support verschwinden dadurch nicht.",
+            'body2' => "Ein gehostetes Abonnement bezahlt die Infrastruktur hinter Ihrem Konto und finanziert die Weiterentwicklung von Monica für alle, auch für jene, die sie selbst hosten.",
+            'quote' => "Sie bezahlen uns dafür, Monica zu betreiben, nicht dafür, Ihre eigenen Daten freizuschalten.",
+            'aside' => "Server sind einfach Computer, die Rechnungen schicken.",
+        ],
+
+        'noCharge' => [
+            'title' => "Wofür wir nichts berechnen",
+            'items' => [
+                ['title' => "Mehr Kontakte", 'body' => "Ihr Preis steigt nicht, weil Sie mehr Menschen kennen."],
+                ['title' => "Mehr Erinnerungen", 'body' => "Sich an Jahrestage zu erinnern ist schon stressig genug."],
+                ['title' => "Datenexporte", 'body' => "Ihre Daten mitzunehmen ist ein Recht, keine Zusatzfunktion."],
+                ['title' => "Grundlegende Privatsphäre", 'body' => "Wir verkaufen kein Privatsphäre-Upgrade. Privatsphäre ist die Voreinstellung."],
+                ['title' => "Kündigen", 'body' => "Es gibt keine Kündigungsgebühren und kein zeremonielles Trennungsgespräch."],
+                ['title' => "Die API nutzen", 'body' => "Die API gehört zum Produkt, sie ist keine gesonderte Verhandlung."],
+            ],
+        ],
+
+        'leaving' => [
+            'title' => "Ihr Abonnement darf enden. Ihr Zugang zu Ihren Daten nicht.",
+            'body' => "Sie können Ihre Daten jederzeit exportieren.",
+            'body2' => "Nach der Kündigung bleibt Ihr Konto bis zum Ende des bezahlten Abrechnungszeitraums zugänglich. Danach halten wir es für eine festgelegte Schonfrist bereit, bevor es gelöscht wird.",
+            'steps' => [
+                ['label' => "Kündigen", 'body' => "Ihr Tarif bleibt bis zum Ende des Abrechnungszeitraums aktiv."],
+                ['label' => "Exportieren", 'body' => "Laden Sie Ihre Daten vor oder nach der Kündigung herunter, während der Schonfrist."],
+                ['label' => "Löschen", 'body' => "Löschen Sie Ihr Konto sofort in den Einstellungen, wann immer Sie möchten."],
+            ],
+            'note' => "Schonfrist, Exportformate und Löschfristen sind in der Aufbewahrungsrichtlinie festgelegt.",
+        ],
+
+        'trackRecord' => [
+            'title' => "Quelloffen, bevor das eine Preisstrategie war",
+            'body' => "Monica wird seit 2017 öffentlich entwickelt.",
+            'body2' => "Das Projekt hat :count Sterne auf GitHub gesammelt, wurde mehrfach als Repository der Woche ausgewählt, stand an der Spitze von Product Hunt und wurde von der Open-Source-Community ausgezeichnet.",
+            'starsLabel' => "Sterne auf GitHub",
+            'since' => "2017",
+            'sinceLabel' => "Quelloffen seit",
+            'launch' => "Nr. 1 des Tages",
+            'launchLabel' => "Product Hunt",
+            'featured' => "Repository der Woche",
+            'featuredLabel' => "Mehrfach hervorgehoben",
+            'cta' => "Monica auf GitHub ansehen",
+        ],
+
+        'faq' => [
+            'title' => "Fragen zum Bezahlen von Monica",
+            'items' => [
+                ['q' => "Was kostet Monica?", 'a' => [
+                    "Gehostete Monica kostet 9 USD pro Monat oder 90 USD pro Jahr.",
+                    "Sie können Monica auch kostenlos auf einer Infrastruktur hosten, die Sie verwalten.",
+                ]],
+                ['q' => "Gilt der Preis pro Nutzer oder pro Kontakt?", 'a' => "Nein. Der gehostete Tarif hat einen Preis pro Konto und enthält unbegrenzte Kontakte."],
+                ['q' => "Ist Monica wirklich quelloffen?", 'a' => [
+                    "Ja. Der Quellcode von Monica ist öffentlich, und das Projekt hat :count Sterne auf GitHub.",
+                    "Monica v3 wird unter der MIT-Lizenz veröffentlicht.",
+                ], 'link' => ['label' => "Mehr über Monica v3 lesen", 'page' => 'v3']],
+                ['q' => "Ist Selbst-Hosten kostenlos?", 'a' => "Monica berechnet nichts für die selbst gehostete Software. Server und Infrastrukturkosten tragen Sie."],
+                ['q' => "Unterscheidet sich die gehostete von der selbst gehosteten Version?", 'a' => [
+                    "Beide nutzen dieselbe Anwendung.",
+                    "Der gehostete Dienst umfasst Infrastruktur, verwaltete Updates, Sicherungen, Überwachung, E-Mail-Versand und Support. Einzelne Integrationen, die auf von Monica betriebener Infrastruktur beruhen, kann es nur im gehosteten Dienst geben.",
+                ]],
+                ['q' => "Kann ich von gehostet zu selbst gehostet wechseln?", 'a' => "Ja. Sie können Ihre Monica-Daten exportieren und in eine kompatible selbst gehostete Installation importieren."],
+                ['q' => "Kann ich jederzeit kündigen?", 'a' => "Ja. Kündigen Sie in Ihren Kontoeinstellungen. Ihr Abonnement bleibt bis zum Ende des laufenden Abrechnungszeitraums aktiv."],
+                ['q' => "Gibt es Kündigungsgebühren?", 'a' => "Nein. Gehen sollte kein Lösegeld kosten."],
+                ['q' => "Was passiert, wenn meine Zahlung fehlschlägt?", 'a' => [
+                    "Wir benachrichtigen Sie und versuchen die Zahlung erneut, bevor wir das Konto einschränken.",
+                    "Ihre Daten werden nicht gelöscht, weil eine Karte abgelaufen ist.",
+                ]],
+                ['q' => "Wie funktionieren Rückerstattungen?", 'a' => [
+                    "Wenn Ihnen versehentlich etwas berechnet wurde oder Sie das Kündigen vergessen haben, melden Sie sich innerhalb von 30 Tagen. Wir prüfen die Anfrage wie vernünftige Menschen.",
+                    "Jahresabonnements können innerhalb der in unserer Rückerstattungsrichtlinie festgelegten Frist erstattet werden. Für Konten, die den Dienst ernsthaft missbraucht haben, gibt es keine Rückerstattung.",
+                ]],
+                ['q' => "Wird der Preis steigen?", 'a' => [
+                    "Preise können sich mit Monica ändern, aber wir informieren bestehende Abonnentinnen und Abonnenten vorher.",
+                    "Wir ändern Preise nicht stillschweigend in der Hoffnung, dass es niemand merkt.",
+                ]],
+                ['q' => "Sind Steuern enthalten?", 'a' => "Ob die angezeigten Preise Steuern enthalten, hängt von Ihrem Land und der geltenden Rechtslage ab. Der Endbetrag wird vor der Zahlung angezeigt."],
+                ['q' => "Speichert Monica meine Zahlungsdaten?", 'a' => "Zahlungsdaten werden von unserem Zahlungsdienstleister verarbeitet. Monica speichert keine vollständigen Kartennummern."],
+                ['q' => "Werden meine Daten für Werbung genutzt?", 'a' => "Nein. Monica verkauft Ihre persönlichen Daten nicht, zeigt keine Werbung und nutzt die Menschen in Ihrem Konto nicht für Werbeprofile."],
+                ['q' => "Werden meine Daten zum Training von KI-Modellen genutzt?", 'a' => "Kein Modell wird auf den privaten Inhalten Ihres Monica-Kontos trainiert."],
+                ['q' => "Sind Sicherungen enthalten?", 'a' => [
+                    "Ja, der gehostete Dienst enthält verwaltete Sicherungen.",
+                    "Bei selbst gehosteten Installationen richten Sie Ihre Sicherungen selbst ein und testen sie.",
+                ]],
+                ['q' => "Kann ich alles exportieren?", 'a' => "Sie können Kontakte, Beziehungen, Notizen, Erinnerungen, Aktivitäten, eigene Felder und weitere unterstützte Kontodaten exportieren. Anhänge sind im dokumentierten Exportformat enthalten."],
+                ['q' => "Kann ich mein Konto löschen?", 'a' => "Ja. Die Kontolöschung finden Sie in den Einstellungen, ohne den Support zu kontaktieren."],
+                ['q' => "Bieten Sie Rabatte an?", 'a' => "Derzeit nicht. Uns ist ein verständlicher Preis lieber als ein System, in dem alle einzeln verhandeln."],
+                ['q' => "Bieten Sie Lifetime-Tarife an?", 'a' => "Nein. Server verursachen weiterhin Kosten, auch nachdem motivierende Startkampagnen vorbei sind."],
+                ['q' => "Bieten Sie einen Enterprise-Tarif an?", 'a' => [
+                    "Für die Nutzung von Monica ist kein Vertriebsgespräch nötig.",
+                    "Bei Fragen zu Sicherheit, Beschaffung oder Hosting in größerem Umfang schreiben Sie uns.",
+                ]],
+                ['q' => "Kann ich in einer anderen Währung zahlen?", 'a' => "Die Abrechnung erfolgt derzeit in USD. Ihre Bank kann den Betrag umrechnen und eine Fremdwährungsgebühr berechnen."],
+                ['q' => "Unterstützt ein Abonnement das Open-Source-Projekt?", 'a' => "Ja. Gehostete Abonnements finanzieren Infrastruktur, Wartung, Support und die weitere quelloffene Entwicklung von Monica."],
+            ],
+        ],
+
+        'finalCta' => [
+            'title' => "Ihr Gedächtnis hat genug unbezahlt gearbeitet.",
+            'body' => "Nutzen Sie die gehostete Version und überlassen Sie uns die Infrastruktur, oder installieren Sie Monica auf Ihrem eigenen Server.",
+            'body2' => "So oder so bleiben Ihre Kontakte Menschen, keine Leads.",
+            'primaryCta' => "Mit Monica beginnen",
+            'secondaryCta' => "Monica selbst hosten",
+            'note' => "Ein einfacher gehosteter Tarif · Selbst hosten kostenlos · Quelloffen",
+        ],
     ],
 
     'footer' => [

--- a/lang/en.php
+++ b/lang/en.php
@@ -25,6 +25,11 @@ return [
             'description' => "Monica helps you remember the people you care about: what is happening in their life, important dates, previous conversations, and when to get back in touch. Private, open source, self-hostable.",
         ],
 
+        'pricing' => [
+            'title' => "Monica pricing — one hosted plan, or self-host for free",
+            'description' => "Hosted Monica is $9 USD per month or $90 per year, with unlimited contacts and no per-contact pricing. Or self-host the open-source application for free on your own infrastructure.",
+        ],
+
         'v3' => [
             'title' => "Monica v3 — rebuilt for the next ten years",
             'description' => "Monica v3 is a ground-up rebuild of the open-source personal CRM: records you design, a journal connected to everything, a complete API, and a proper mobile experience. Still open source, now MIT licensed. Coming before the end of 2026.",
@@ -394,6 +399,205 @@ return [
         'primaryCta' => "Start using Monica",
         'secondaryCta' => "View Monica v3",
         'note' => "Open source · Self-hostable · No credit card required",
+    ],
+
+    /** The /pricing page. Prices are the design's; change them here, once per locale. */
+    'pricing' => [
+        'eyebrow' => "Simple pricing",
+        'title' => "One hosted plan. No relationship-based pricing.",
+        'lede' => "Use Monica on our servers for one predictable price, or self-host it for free.",
+        'lede2' => "We do not charge per contact, per reminder, per important birthday, or per person you are trying not to disappoint.",
+        'currency' => "Prices in USD",
+        'taxFootnote' => "Prices are shown in USD. Applicable taxes are calculated before payment.",
+
+        'billing' => [
+            'label' => "Billing period",
+            'yearly' => "Yearly — save 2 months",
+            'monthly' => "Monthly",
+        ],
+
+        'hosted' => [
+            'title' => "Hosted Monica",
+            'body' => "For people who want Monica without maintaining a server.",
+            'yearlyPrice' => "$90",
+            'yearlyPeriod' => "USD / year",
+            'yearlyNote' => "Two months free when billed yearly.",
+            'monthlyPrice' => "$9",
+            'monthlyPeriod' => "USD / month",
+            'monthlyNote' => "Billed monthly. Switch to yearly for two months free.",
+            'taxNote' => "Taxes may apply depending on your location.",
+            'cta' => "Start using Monica",
+            'trial' => "30-day trial · No credit card required during the trial",
+            'listTitle' => "Everything you need to remember the people who matter:",
+            'items' => [
+                "unlimited contacts;",
+                "unlimited notes;",
+                "unlimited reminders;",
+                "unlimited activities and journal entries;",
+                "relationship management;",
+                "custom fields and sections;",
+                "file attachments;",
+                "data export;",
+                "automatic updates;",
+                "managed backups;",
+                "email support;",
+                "access from phone, tablet, and desktop;",
+                "all future hosted features included.",
+            ],
+            'aside' => "No fee for having a large family.",
+            'footnote' => "Cancel whenever you want. Your contacts will not be held hostage.",
+        ],
+
+        'selfHosted' => [
+            'title' => "Prefer your own server?",
+            'body' => "Monica is open source and can be installed on infrastructure you control.",
+            'price' => "$0",
+            'period' => "from Monica",
+            'aside' => "Your hosting provider may still want money. We have not yet defeated capitalism.",
+            'cta' => "View the self-hosting guide",
+            'sourceCta' => "Browse the source on GitHub · :count stars",
+            'listTitle' => "You get the application for free. You provide the server, updates, backups, monitoring, security patches, and the quiet confidence of knowing exactly where your data lives.",
+            'items' => [
+                "the full open-source application;",
+                "unlimited contacts;",
+                "unlimited users, as far as your infrastructure allows;",
+                "full control over your data;",
+                "data import and export;",
+                "community documentation;",
+                "community support;",
+                "the ability to inspect and modify the source code;",
+                "the MIT license in Monica v3.",
+            ],
+            'footnote' => "The self-hosted edition is not a stripped-down demo. It is Monica running on your infrastructure.",
+            'footnote2' => "Managed backups, hosted email delivery, infrastructure monitoring, and direct support are part of the hosted service.",
+        ],
+
+        'compare' => [
+            'title' => "Same Monica. Different person responsible for the server.",
+            'rowHeader' => "What",
+            'hosted' => "Hosted Monica",
+            'selfHosted' => "Self-hosted Monica",
+            'rows' => [
+                ['label' => "Monica software", 'hosted' => "Included", 'selfHosted' => "Included"],
+                ['label' => "Contacts", 'hosted' => "Unlimited", 'selfHosted' => "Unlimited"],
+                ['label' => "Updates", 'hosted' => "Automatic", 'selfHosted' => "You install them"],
+                ['label' => "Backups", 'hosted' => "Managed by Monica", 'selfHosted' => "You manage them"],
+                ['label' => "Server maintenance", 'hosted' => "Managed by Monica", 'selfHosted' => "You manage it"],
+                ['label' => "Data location", 'hosted' => "Monica infrastructure", 'selfHosted' => "Your infrastructure"],
+                ['label' => "Technical knowledge required", 'hosted' => "None", 'selfHosted' => "Some"],
+                ['label' => "Support", 'hosted' => "Email support", 'selfHosted' => "Community support"],
+                ['label' => "Cost", 'hosted' => "Monthly or yearly subscription", 'selfHosted' => "Free software plus hosting costs"],
+                ['label' => "Best for", 'hosted' => "People who want Monica to work", 'selfHosted' => "People who enjoy servers, or are required to"],
+            ],
+        ],
+
+        'whyPay' => [
+            'title' => "Why pay when Monica is open source?",
+            'body' => "Open source means you can run, inspect, modify, and contribute to Monica. It does not make servers, backups, email delivery, security work, or support disappear.",
+            'body2' => "A hosted subscription pays for the infrastructure that runs your account and helps fund the continued development of Monica for everyone—including people who self-host it.",
+            'quote' => "You pay us to operate Monica, not to unlock your own data.",
+            'aside' => "Servers are just computers that send invoices.",
+        ],
+
+        'noCharge' => [
+            'title' => "Things we do not charge for",
+            'items' => [
+                ['title' => "More contacts", 'body' => "Your pricing does not increase because you know more people."],
+                ['title' => "More reminders", 'body' => "Remembering anniversaries is already stressful enough."],
+                ['title' => "Data exports", 'body' => "Taking your data with you is a right, not a premium feature."],
+                ['title' => "Basic privacy", 'body' => "We do not sell a privacy upgrade. Privacy is the default."],
+                ['title' => "Cancelling", 'body' => "There are no cancellation fees and no ceremonial breakup call."],
+                ['title' => "Using the API", 'body' => "The API is part of the product, not a separate enterprise negotiation."],
+            ],
+        ],
+
+        'leaving' => [
+            'title' => "Your subscription can end. Your access to your data should not.",
+            'body' => "You can export your data at any time.",
+            'body2' => "When you cancel, your account remains accessible until the end of the paid billing period. After that, we keep the account available for a defined grace period before deletion.",
+            'steps' => [
+                ['label' => "Cancel", 'body' => "Your plan remains active until the end of the billing period."],
+                ['label' => "Export", 'body' => "Download your data before or after cancellation, during the grace period."],
+                ['label' => "Delete", 'body' => "Delete your account immediately from Settings when you choose."],
+            ],
+            'note' => "Grace period, export formats and deletion timelines are set out in the retention policy.",
+        ],
+
+        'trackRecord' => [
+            'title' => "Open source before it was a pricing strategy",
+            'body' => "Monica has been developed in public since 2017.",
+            'body2' => "The project has earned :count GitHub stars, been selected as Repository of the Week multiple times, reached the top of Product Hunt, and received recognition from the open-source community.",
+            'starsLabel' => "GitHub stars",
+            'since' => "2017",
+            'sinceLabel' => "Open source since",
+            'launch' => "#1 Product of the Day",
+            'launchLabel' => "Product Hunt",
+            'featured' => "Repository of the Week",
+            'featuredLabel' => "Featured multiple times",
+            'cta' => "See Monica on GitHub",
+        ],
+
+        'faq' => [
+            'title' => "Questions about paying for Monica",
+            'items' => [
+                ['q' => "How much does Monica cost?", 'a' => [
+                    "Hosted Monica costs \$9 USD per month or \$90 USD per year.",
+                    "You can also self-host Monica for free on infrastructure you manage.",
+                ]],
+                ['q' => "Is the price per user or per contact?", 'a' => "No. The hosted plan has one account price and includes unlimited contacts."],
+                ['q' => "Is Monica really open source?", 'a' => [
+                    "Yes. Monica's source code is publicly available, and the project has :count stars on GitHub.",
+                    "Monica v3 will be released under the MIT license.",
+                ], 'link' => ['label' => "Read about Monica v3", 'page' => 'v3']],
+                ['q' => "Is self-hosting free?", 'a' => "Monica does not charge for the self-hosted software. You are responsible for the server and any infrastructure costs."],
+                ['q' => "Is the hosted version different from the self-hosted version?", 'a' => [
+                    "They use the same core application.",
+                    "The hosted service includes infrastructure, managed updates, backups, monitoring, email delivery, and support. Some integrations that depend on Monica-operated infrastructure may be available only on the hosted service.",
+                ]],
+                ['q' => "Can I move from hosted to self-hosted?", 'a' => "Yes. You can export your Monica data and import it into a compatible self-hosted installation."],
+                ['q' => "Can I cancel at any time?", 'a' => "Yes. Cancel from your account settings. Your subscription remains active until the end of the current billing period."],
+                ['q' => "Are there cancellation fees?", 'a' => "No. Leaving should not require a ransom payment."],
+                ['q' => "What happens if my payment fails?", 'a' => [
+                    "We will notify you and retry the payment before restricting the account.",
+                    "Your data is not deleted immediately because a card expired.",
+                ]],
+                ['q' => "How do refunds work?", 'a' => [
+                    "If you were charged by mistake or forgot to cancel, contact us within 30 days. We will review the request like reasonable human beings.",
+                    "Annual subscriptions can be refunded within the period defined in our refund policy. Refunds are not available for accounts that have seriously abused the service.",
+                ]],
+                ['q' => "Will the price increase?", 'a' => [
+                    "Prices may change as Monica evolves, but we will notify existing subscribers in advance.",
+                    "We do not change prices silently and hope nobody notices.",
+                ]],
+                ['q' => "Are taxes included?", 'a' => "Displayed prices exclude or include taxes depending on your location and applicable law. The final amount is shown before payment."],
+                ['q' => "Is my payment information stored by Monica?", 'a' => "Payment information is processed by our payment provider. Monica does not store complete card numbers."],
+                ['q' => "Is my data used for advertising?", 'a' => "No. Monica does not sell your personal data, display advertising, or use the people in your account to build advertising profiles."],
+                ['q' => "Is my data used to train AI models?", 'a' => "No model is trained on the private contents of your Monica account."],
+                ['q' => "Are backups included?", 'a' => [
+                    "Yes, the hosted service includes managed backups.",
+                    "Self-hosted installations require you to configure and test your own backups.",
+                ]],
+                ['q' => "Can I export everything?", 'a' => "You can export contacts, relationships, notes, reminders, activities, custom fields, and other supported account data. Attachments are included using the documented export format."],
+                ['q' => "Can I delete my account?", 'a' => "Yes. Account deletion is available from Settings and does not require contacting support."],
+                ['q' => "Do you offer discounts?", 'a' => "Not currently. We prefer one understandable price over a system where everyone negotiates separately."],
+                ['q' => "Do you offer lifetime plans?", 'a' => "No. Servers continue having expenses after motivational launch campaigns end."],
+                ['q' => "Do you offer an enterprise plan?", 'a' => [
+                    "No enterprise sales call is required to use Monica.",
+                    "For security, procurement, or volume-hosting questions, contact us.",
+                ]],
+                ['q' => "Can I pay in another currency?", 'a' => "Billing is currently in USD. Your bank may convert the amount and charge a currency-conversion fee."],
+                ['q' => "Does subscribing support the open-source project?", 'a' => "Yes. Hosted subscriptions fund Monica's infrastructure, maintenance, support, and continued open-source development."],
+            ],
+        ],
+
+        'finalCta' => [
+            'title' => "Your memory has done enough unpaid work.",
+            'body' => "Use the hosted version and let us manage the infrastructure, or install Monica on your own server.",
+            'body2' => "Either way, your contacts remain people, not leads.",
+            'primaryCta' => "Start using Monica",
+            'secondaryCta' => "Self-host Monica",
+            'note' => "One simple hosted plan · Free to self-host · Open source",
+        ],
     ],
 
     'footer' => [

--- a/lang/es.php
+++ b/lang/es.php
@@ -15,6 +15,11 @@ return [
             'description' => "Monica te ayuda a recordar a las personas que te importan: qué está pasando en su vida, las fechas importantes, vuestras conversaciones anteriores y cuándo volver a hablar. Privado, de código abierto, alojable por ti.",
         ],
 
+        'pricing' => [
+            'title' => "Precios de Monica — un plan alojado, o autoalojamiento gratis",
+            'description' => "Monica alojada cuesta 9 USD al mes o 90 USD al año, con contactos ilimitados y sin precio por contacto. O aloja gratis la aplicación de código abierto en tu propia infraestructura.",
+        ],
+
         'v3' => [
             'title' => "Monica v3 — reconstruida para los próximos diez años",
             'description' => "Monica v3 es una reconstrucción completa del CRM personal de código abierto: fichas que diseñas tú, un diario conectado con todo lo demás, una API completa y una experiencia móvil de verdad. Sigue siendo de código abierto, ahora con licencia MIT. Antes de que acabe 2026.",
@@ -383,6 +388,205 @@ return [
         'primaryCta' => "Empezar con Monica",
         'secondaryCta' => "Ver Monica v3",
         'note' => "Código abierto · Alojable por ti · Sin tarjeta de crédito",
+    ],
+
+    /** La página /precios. Los precios vienen del diseño; cámbialos aquí, por locale. */
+    'pricing' => [
+        'eyebrow' => "Precios sencillos",
+        'title' => "Un solo plan alojado. Sin precios por relación.",
+        'lede' => "Usa Monica en nuestros servidores por un precio predecible, o alójala tú mismo gratis.",
+        'lede2' => "No cobramos por contacto, por recordatorio, por cumpleaños importante ni por persona a la que intentas no defraudar.",
+        'currency' => "Precios en USD",
+        'taxFootnote' => "Los precios se muestran en USD. Los impuestos aplicables se calculan antes del pago.",
+
+        'billing' => [
+            'label' => "Periodo de facturación",
+            'yearly' => "Anual — 2 meses gratis",
+            'monthly' => "Mensual",
+        ],
+
+        'hosted' => [
+            'title' => "Monica alojada",
+            'body' => "Para quien quiere Monica sin mantener un servidor.",
+            'yearlyPrice' => "90 $",
+            'yearlyPeriod' => "USD / año",
+            'yearlyNote' => "Dos meses gratis con facturación anual.",
+            'monthlyPrice' => "9 $",
+            'monthlyPeriod' => "USD / mes",
+            'monthlyNote' => "Facturación mensual. Cambia a anual y consigue dos meses gratis.",
+            'taxNote' => "Pueden aplicarse impuestos según tu país.",
+            'cta' => "Empezar con Monica",
+            'trial' => "Prueba de 30 días · Sin tarjeta durante la prueba",
+            'listTitle' => "Todo lo necesario para recordar a las personas que importan:",
+            'items' => [
+                "contactos ilimitados;",
+                "notas ilimitadas;",
+                "recordatorios ilimitados;",
+                "actividades y entradas de diario ilimitadas;",
+                "gestión de relaciones;",
+                "campos y secciones personalizados;",
+                "archivos adjuntos;",
+                "exportación de datos;",
+                "actualizaciones automáticas;",
+                "copias de seguridad gestionadas;",
+                "soporte por correo;",
+                "acceso desde móvil, tableta y ordenador;",
+                "todas las funciones alojadas futuras incluidas.",
+            ],
+            'aside' => "Sin recargo por tener una familia grande.",
+            'footnote' => "Cancela cuando quieras. Tus contactos no quedarán secuestrados.",
+        ],
+
+        'selfHosted' => [
+            'title' => "¿Prefieres tu propio servidor?",
+            'body' => "Monica es de código abierto y se instala en la infraestructura que tú controles.",
+            'price' => "0 $",
+            'period' => "por parte de Monica",
+            'aside' => "Puede que tu proveedor de alojamiento sí quiera dinero. Todavía no hemos derrotado al capitalismo.",
+            'cta' => "Ver la guía de autoalojamiento",
+            'sourceCta' => "Ver el código en GitHub · :count estrellas",
+            'listTitle' => "La aplicación es gratuita. Tú pones el servidor, las actualizaciones, las copias de seguridad, la supervisión, los parches de seguridad y la tranquilidad de saber exactamente dónde viven tus datos.",
+            'items' => [
+                "la aplicación de código abierto completa;",
+                "contactos ilimitados;",
+                "tantos usuarios como permita tu infraestructura;",
+                "control total sobre tus datos;",
+                "importación y exportación de datos;",
+                "documentación de la comunidad;",
+                "soporte de la comunidad;",
+                "la posibilidad de inspeccionar y modificar el código;",
+                "la licencia MIT en Monica v3.",
+            ],
+            'footnote' => "La edición autoalojada no es una demo recortada. Es Monica funcionando en tu infraestructura.",
+            'footnote2' => "Las copias de seguridad gestionadas, el envío de correo, la supervisión de la infraestructura y el soporte directo forman parte del servicio alojado.",
+        ],
+
+        'compare' => [
+            'title' => "La misma Monica. Otra persona a cargo del servidor.",
+            'rowHeader' => "Qué",
+            'hosted' => "Monica alojada",
+            'selfHosted' => "Monica autoalojada",
+            'rows' => [
+                ['label' => "Software Monica", 'hosted' => "Incluido", 'selfHosted' => "Incluido"],
+                ['label' => "Contactos", 'hosted' => "Ilimitados", 'selfHosted' => "Ilimitados"],
+                ['label' => "Actualizaciones", 'hosted' => "Automáticas", 'selfHosted' => "Las instalas tú"],
+                ['label' => "Copias de seguridad", 'hosted' => "Gestionadas por Monica", 'selfHosted' => "Las gestionas tú"],
+                ['label' => "Mantenimiento del servidor", 'hosted' => "Gestionado por Monica", 'selfHosted' => "Lo gestionas tú"],
+                ['label' => "Ubicación de los datos", 'hosted' => "Infraestructura de Monica", 'selfHosted' => "Tu infraestructura"],
+                ['label' => "Conocimientos técnicos necesarios", 'hosted' => "Ninguno", 'selfHosted' => "Algunos"],
+                ['label' => "Soporte", 'hosted' => "Soporte por correo", 'selfHosted' => "Soporte de la comunidad"],
+                ['label' => "Coste", 'hosted' => "Suscripción mensual o anual", 'selfHosted' => "Software gratuito más costes de alojamiento"],
+                ['label' => "Ideal para", 'hosted' => "Quien quiere que Monica funcione", 'selfHosted' => "Quien disfruta con los servidores, o no tiene alternativa"],
+            ],
+        ],
+
+        'whyPay' => [
+            'title' => "¿Por qué pagar si Monica es de código abierto?",
+            'body' => "El código abierto te permite ejecutar, inspeccionar y modificar Monica, y contribuir a ella. No hace desaparecer los servidores, las copias de seguridad, el envío de correo, el trabajo de seguridad ni el soporte.",
+            'body2' => "Una suscripción alojada paga la infraestructura que hace funcionar tu cuenta y financia el desarrollo continuo de Monica para todo el mundo, incluidas las personas que la autoalojan.",
+            'quote' => "Nos pagas por operar Monica, no por desbloquear tus propios datos.",
+            'aside' => "Los servidores son solo ordenadores que envían facturas.",
+        ],
+
+        'noCharge' => [
+            'title' => "Cosas por las que no cobramos",
+            'items' => [
+                ['title' => "Más contactos", 'body' => "Tu precio no sube porque conozcas a más gente."],
+                ['title' => "Más recordatorios", 'body' => "Acordarse de los aniversarios ya es bastante estresante."],
+                ['title' => "Exportar datos", 'body' => "Llevarte tus datos es un derecho, no una función de pago."],
+                ['title' => "La privacidad básica", 'body' => "No vendemos una mejora de privacidad. La privacidad es lo predeterminado."],
+                ['title' => "Cancelar", 'body' => "No hay penalizaciones por cancelar ni llamada de ruptura ceremonial."],
+                ['title' => "Usar la API", 'body' => "La API es parte del producto, no una negociación aparte."],
+            ],
+        ],
+
+        'leaving' => [
+            'title' => "Tu suscripción puede terminar. Tu acceso a tus datos, no.",
+            'body' => "Puedes exportar tus datos en cualquier momento.",
+            'body2' => "Al cancelar, tu cuenta sigue accesible hasta el final del periodo pagado. Después la mantenemos disponible durante un periodo de gracia definido antes de eliminarla.",
+            'steps' => [
+                ['label' => "Cancelar", 'body' => "Tu plan sigue activo hasta el final del periodo de facturación."],
+                ['label' => "Exportar", 'body' => "Descarga tus datos antes o después de cancelar, durante el periodo de gracia."],
+                ['label' => "Eliminar", 'body' => "Elimina tu cuenta al instante desde Ajustes cuando quieras."],
+            ],
+            'note' => "El periodo de gracia, los formatos de exportación y los plazos de eliminación se detallan en la política de conservación.",
+        ],
+
+        'trackRecord' => [
+            'title' => "De código abierto antes de que fuera una estrategia de precios",
+            'body' => "Monica se desarrolla en público desde 2017.",
+            'body2' => "El proyecto ha reunido :count estrellas en GitHub, ha sido elegido varias veces repositorio de la semana, ha llegado a lo más alto de Product Hunt y ha recibido reconocimiento de la comunidad de código abierto.",
+            'starsLabel' => "Estrellas en GitHub",
+            'since' => "2017",
+            'sinceLabel' => "De código abierto desde",
+            'launch' => "N.º 1 del día",
+            'launchLabel' => "Product Hunt",
+            'featured' => "Repositorio de la semana",
+            'featuredLabel' => "Destacado varias veces",
+            'cta' => "Ver Monica en GitHub",
+        ],
+
+        'faq' => [
+            'title' => "Preguntas sobre pagar por Monica",
+            'items' => [
+                ['q' => "¿Cuánto cuesta Monica?", 'a' => [
+                    "Monica alojada cuesta 9 USD al mes o 90 USD al año.",
+                    "También puedes alojar Monica gratis en una infraestructura que gestiones tú.",
+                ]],
+                ['q' => "¿El precio es por usuario o por contacto?", 'a' => "No. El plan alojado tiene un único precio por cuenta e incluye contactos ilimitados."],
+                ['q' => "¿Monica es realmente de código abierto?", 'a' => [
+                    "Sí. El código de Monica es público y el proyecto tiene :count estrellas en GitHub.",
+                    "Monica v3 se publicará con licencia MIT.",
+                ], 'link' => ['label' => "Leer sobre Monica v3", 'page' => 'v3']],
+                ['q' => "¿Autoalojar es gratis?", 'a' => "Monica no cobra por el software autoalojado. El servidor y los costes de infraestructura corren de tu cuenta."],
+                ['q' => "¿La versión alojada es distinta de la autoalojada?", 'a' => [
+                    "Usan la misma aplicación.",
+                    "El servicio alojado incluye infraestructura, actualizaciones gestionadas, copias de seguridad, supervisión, envío de correo y soporte. Algunas integraciones que dependen de infraestructura operada por Monica pueden existir solo en el servicio alojado.",
+                ]],
+                ['q' => "¿Puedo pasar de alojada a autoalojada?", 'a' => "Sí. Puedes exportar tus datos de Monica e importarlos en una instalación autoalojada compatible."],
+                ['q' => "¿Puedo cancelar cuando quiera?", 'a' => "Sí. Cancela desde los ajustes de tu cuenta. Tu suscripción sigue activa hasta el final del periodo en curso."],
+                ['q' => "¿Hay penalizaciones por cancelar?", 'a' => "No. Marcharse no debería costar un rescate."],
+                ['q' => "¿Qué pasa si falla mi pago?", 'a' => [
+                    "Te avisaremos y volveremos a intentar el cobro antes de restringir la cuenta.",
+                    "Tus datos no se eliminan porque haya caducado una tarjeta.",
+                ]],
+                ['q' => "¿Cómo funcionan los reembolsos?", 'a' => [
+                    "Si se te ha cobrado por error o has olvidado cancelar, escríbenos en un plazo de 30 días. Revisaremos la solicitud como personas razonables.",
+                    "Las suscripciones anuales pueden reembolsarse dentro del plazo definido en nuestra política de reembolsos. No hay reembolso para cuentas que hayan abusado gravemente del servicio.",
+                ]],
+                ['q' => "¿Subirá el precio?", 'a' => [
+                    "Los precios pueden cambiar a medida que Monica evoluciona, pero avisaremos con antelación a quienes ya estén suscritos.",
+                    "No cambiamos los precios en silencio esperando que nadie se dé cuenta.",
+                ]],
+                ['q' => "¿Los impuestos están incluidos?", 'a' => "Que los precios mostrados incluyan o excluyan impuestos depende de tu país y de la ley aplicable. El importe final se muestra antes del pago."],
+                ['q' => "¿Monica guarda mis datos de pago?", 'a' => "Los datos de pago los procesa nuestro proveedor. Monica no almacena números de tarjeta completos."],
+                ['q' => "¿Se usan mis datos para publicidad?", 'a' => "No. Monica no vende tus datos personales, no muestra publicidad y no usa a las personas de tu cuenta para crear perfiles publicitarios."],
+                ['q' => "¿Se usan mis datos para entrenar modelos de IA?", 'a' => "Ningún modelo se entrena con el contenido privado de tu cuenta de Monica."],
+                ['q' => "¿Las copias de seguridad están incluidas?", 'a' => [
+                    "Sí, el servicio alojado incluye copias de seguridad gestionadas.",
+                    "En las instalaciones autoalojadas tienes que configurar y probar tus propias copias.",
+                ]],
+                ['q' => "¿Puedo exportarlo todo?", 'a' => "Puedes exportar contactos, relaciones, notas, recordatorios, actividades, campos personalizados y otros datos admitidos de la cuenta. Los adjuntos se incluyen con el formato de exportación documentado."],
+                ['q' => "¿Puedo eliminar mi cuenta?", 'a' => "Sí. La eliminación de la cuenta está en Ajustes y no requiere contactar con soporte."],
+                ['q' => "¿Ofrecéis descuentos?", 'a' => "Por ahora no. Preferimos un precio comprensible a un sistema en el que cada cual negocia por su cuenta."],
+                ['q' => "¿Ofrecéis planes de por vida?", 'a' => "No. Los servidores siguen teniendo gastos cuando acaban las campañas de lanzamiento motivadoras."],
+                ['q' => "¿Ofrecéis un plan enterprise?", 'a' => [
+                    "No hace falta ninguna llamada comercial para usar Monica.",
+                    "Para cuestiones de seguridad, compras o alojamiento a gran escala, escríbenos.",
+                ]],
+                ['q' => "¿Puedo pagar en otra moneda?", 'a' => "La facturación es actualmente en USD. Tu banco puede convertir el importe y cobrar una comisión de cambio."],
+                ['q' => "¿Suscribirse apoya al proyecto de código abierto?", 'a' => "Sí. Las suscripciones alojadas financian la infraestructura, el mantenimiento, el soporte y el desarrollo abierto continuo de Monica."],
+            ],
+        ],
+
+        'finalCta' => [
+            'title' => "Tu memoria ya ha hecho suficientes horas no pagadas.",
+            'body' => "Usa la versión alojada y deja que gestionemos la infraestructura, o instala Monica en tu propio servidor.",
+            'body2' => "En cualquiera de los dos casos, tus contactos siguen siendo personas, no clientes potenciales.",
+            'primaryCta' => "Empezar con Monica",
+            'secondaryCta' => "Autoalojar Monica",
+            'note' => "Un plan alojado sencillo · Autoalojamiento gratuito · Código abierto",
+        ],
     ],
 
     'footer' => [

--- a/lang/fr.php
+++ b/lang/fr.php
@@ -15,6 +15,11 @@ return [
             'description' => "Monica vous aide à vous souvenir des gens qui comptent : ce qui se passe dans leur vie, les dates importantes, vos conversations passées et le moment de reprendre contact. Privé, open source, auto-hébergeable.",
         ],
 
+        'pricing' => [
+            'title' => "Tarifs Monica — une offre hébergée, ou l'auto-hébergement gratuit",
+            'description' => "Monica hébergée coûte 9 USD par mois ou 90 USD par an, avec des contacts illimités et aucun tarif au contact. Ou hébergez gratuitement l'application open source sur votre propre infrastructure.",
+        ],
+
         'v3' => [
             'title' => "Monica v3 — reconstruite pour les dix prochaines années",
             'description' => "Monica v3 est une reconstruction complète du CRM personnel open source : des fiches que vous concevez, un journal relié à tout le reste, une API complète et une vraie expérience mobile. Toujours open source, désormais sous licence MIT. Avant la fin de 2026.",
@@ -383,6 +388,205 @@ return [
         'primaryCta' => "Commencer avec Monica",
         'secondaryCta' => "Voir Monica v3",
         'note' => "Open source · Auto-hébergeable · Sans carte bancaire",
+    ],
+
+    /** La page /tarifs. Les prix viennent du design ; à changer ici, par locale. */
+    'pricing' => [
+        'eyebrow' => "Tarifs simples",
+        'title' => "Une seule offre hébergée. Aucun tarif à la relation.",
+        'lede' => "Utilisez Monica sur nos serveurs pour un prix prévisible, ou hébergez-la vous-même gratuitement.",
+        'lede2' => "Nous ne facturons ni au contact, ni au rappel, ni à l'anniversaire important, ni à la personne que vous essayez de ne pas décevoir.",
+        'currency' => "Prix en USD",
+        'taxFootnote' => "Les prix sont affichés en USD. Les taxes applicables sont calculées avant le paiement.",
+
+        'billing' => [
+            'label' => "Périodicité de facturation",
+            'yearly' => "Annuel — 2 mois offerts",
+            'monthly' => "Mensuel",
+        ],
+
+        'hosted' => [
+            'title' => "Monica hébergée",
+            'body' => "Pour celles et ceux qui veulent Monica sans entretenir de serveur.",
+            'yearlyPrice' => "90 $",
+            'yearlyPeriod' => "USD / an",
+            'yearlyNote' => "Deux mois offerts en facturation annuelle.",
+            'monthlyPrice' => "9 $",
+            'monthlyPeriod' => "USD / mois",
+            'monthlyNote' => "Facturé au mois. Passez à l'annuel pour deux mois offerts.",
+            'taxNote' => "Des taxes peuvent s'appliquer selon votre pays.",
+            'cta' => "Commencer avec Monica",
+            'trial' => "Essai de 30 jours · Aucune carte bancaire pendant l'essai",
+            'listTitle' => "Tout ce qu'il faut pour se souvenir des gens qui comptent :",
+            'items' => [
+                "contacts illimités ;",
+                "notes illimitées ;",
+                "rappels illimités ;",
+                "activités et entrées de journal illimitées ;",
+                "gestion des relations ;",
+                "champs et sections personnalisés ;",
+                "pièces jointes ;",
+                "export des données ;",
+                "mises à jour automatiques ;",
+                "sauvegardes gérées ;",
+                "support par e-mail ;",
+                "accès depuis téléphone, tablette et ordinateur ;",
+                "toutes les futures fonctionnalités hébergées incluses.",
+            ],
+            'aside' => "Aucun supplément pour une grande famille.",
+            'footnote' => "Résiliez quand vous voulez. Vos contacts ne seront pas pris en otage.",
+        ],
+
+        'selfHosted' => [
+            'title' => "Vous préférez votre propre serveur ?",
+            'body' => "Monica est open source et s'installe sur l'infrastructure de votre choix.",
+            'price' => "0 $",
+            'period' => "côté Monica",
+            'aside' => "Votre hébergeur, lui, voudra sans doute de l'argent. Nous n'avons pas encore vaincu le capitalisme.",
+            'cta' => "Voir le guide d'auto-hébergement",
+            'sourceCta' => "Parcourir le code sur GitHub · :count étoiles",
+            'listTitle' => "L'application est gratuite. Vous fournissez le serveur, les mises à jour, les sauvegardes, la supervision, les correctifs de sécurité, et la tranquillité de savoir exactement où vivent vos données.",
+            'items' => [
+                "l'application open source complète ;",
+                "des contacts illimités ;",
+                "autant d'utilisateurs que votre infrastructure le permet ;",
+                "le contrôle total de vos données ;",
+                "l'import et l'export des données ;",
+                "la documentation communautaire ;",
+                "le support communautaire ;",
+                "la possibilité d'inspecter et de modifier le code source ;",
+                "la licence MIT dans Monica v3.",
+            ],
+            'footnote' => "L'édition auto-hébergée n'est pas une démo bridée. C'est Monica, sur votre infrastructure.",
+            'footnote2' => "Les sauvegardes gérées, l'envoi d'e-mails, la supervision de l'infrastructure et le support direct font partie du service hébergé.",
+        ],
+
+        'compare' => [
+            'title' => "La même Monica. Une autre personne responsable du serveur.",
+            'rowHeader' => "Quoi",
+            'hosted' => "Monica hébergée",
+            'selfHosted' => "Monica auto-hébergée",
+            'rows' => [
+                ['label' => "Logiciel Monica", 'hosted' => "Inclus", 'selfHosted' => "Inclus"],
+                ['label' => "Contacts", 'hosted' => "Illimités", 'selfHosted' => "Illimités"],
+                ['label' => "Mises à jour", 'hosted' => "Automatiques", 'selfHosted' => "Vous les installez"],
+                ['label' => "Sauvegardes", 'hosted' => "Gérées par Monica", 'selfHosted' => "Vous les gérez"],
+                ['label' => "Maintenance du serveur", 'hosted' => "Gérée par Monica", 'selfHosted' => "Vous la gérez"],
+                ['label' => "Emplacement des données", 'hosted' => "Infrastructure Monica", 'selfHosted' => "Votre infrastructure"],
+                ['label' => "Connaissances techniques requises", 'hosted' => "Aucune", 'selfHosted' => "Quelques-unes"],
+                ['label' => "Support", 'hosted' => "Support par e-mail", 'selfHosted' => "Support communautaire"],
+                ['label' => "Coût", 'hosted' => "Abonnement mensuel ou annuel", 'selfHosted' => "Logiciel gratuit plus frais d'hébergement"],
+                ['label' => "Idéal pour", 'hosted' => "Les gens qui veulent que Monica fonctionne", 'selfHosted' => "Les gens qui aiment les serveurs, ou qui y sont contraints"],
+            ],
+        ],
+
+        'whyPay' => [
+            'title' => "Pourquoi payer si Monica est open source ?",
+            'body' => "L'open source vous permet d'exécuter, d'inspecter, de modifier Monica et d'y contribuer. Il ne fait pas disparaître les serveurs, les sauvegardes, l'envoi d'e-mails, le travail de sécurité ni le support.",
+            'body2' => "Un abonnement hébergé paie l'infrastructure qui fait tourner votre compte et finance le développement continu de Monica pour tout le monde, y compris pour celles et ceux qui l'auto-hébergent.",
+            'quote' => "Vous nous payez pour faire tourner Monica, pas pour déverrouiller vos propres données.",
+            'aside' => "Un serveur, c'est un ordinateur qui envoie des factures.",
+        ],
+
+        'noCharge' => [
+            'title' => "Ce que nous ne facturons pas",
+            'items' => [
+                ['title' => "Plus de contacts", 'body' => "Votre tarif n'augmente pas parce que vous connaissez plus de monde."],
+                ['title' => "Plus de rappels", 'body' => "Se souvenir des anniversaires est déjà assez stressant."],
+                ['title' => "L'export des données", 'body' => "Repartir avec vos données est un droit, pas une option payante."],
+                ['title' => "La confidentialité", 'body' => "Nous ne vendons pas d'option vie privée. La confidentialité est la valeur par défaut."],
+                ['title' => "La résiliation", 'body' => "Aucun frais de résiliation, et aucun appel de rupture protocolaire."],
+                ['title' => "L'utilisation de l'API", 'body' => "L'API fait partie du produit, ce n'est pas une négociation à part."],
+            ],
+        ],
+
+        'leaving' => [
+            'title' => "Votre abonnement peut s'arrêter. Votre accès à vos données, non.",
+            'body' => "Vous pouvez exporter vos données à tout moment.",
+            'body2' => "À la résiliation, votre compte reste accessible jusqu'à la fin de la période payée. Ensuite, nous le gardons disponible pendant un délai de grâce défini avant suppression.",
+            'steps' => [
+                ['label' => "Résilier", 'body' => "Votre offre reste active jusqu'à la fin de la période de facturation."],
+                ['label' => "Exporter", 'body' => "Téléchargez vos données avant ou après la résiliation, pendant le délai de grâce."],
+                ['label' => "Supprimer", 'body' => "Supprimez votre compte immédiatement depuis les réglages, quand vous le décidez."],
+            ],
+            'note' => "Le délai de grâce, les formats d'export et les délais de suppression sont détaillés dans la politique de conservation.",
+        ],
+
+        'trackRecord' => [
+            'title' => "Open source avant que ce soit une stratégie tarifaire",
+            'body' => "Monica est développée au grand jour depuis 2017.",
+            'body2' => "Le projet a réuni :count étoiles sur GitHub, a été choisi plusieurs fois comme dépôt de la semaine, est arrivé en tête de Product Hunt et a été reconnu par la communauté open source.",
+            'starsLabel' => "Étoiles sur GitHub",
+            'since' => "2017",
+            'sinceLabel' => "Open source depuis",
+            'launch' => "N° 1 du jour",
+            'launchLabel' => "Product Hunt",
+            'featured' => "Dépôt de la semaine",
+            'featuredLabel' => "Mis en avant plusieurs fois",
+            'cta' => "Voir Monica sur GitHub",
+        ],
+
+        'faq' => [
+            'title' => "Questions sur le paiement de Monica",
+            'items' => [
+                ['q' => "Combien coûte Monica ?", 'a' => [
+                    "Monica hébergée coûte 9 USD par mois ou 90 USD par an.",
+                    "Vous pouvez aussi héberger Monica gratuitement sur une infrastructure que vous gérez.",
+                ]],
+                ['q' => "Le prix est-il par utilisateur ou par contact ?", 'a' => "Non. L'offre hébergée a un seul prix par compte et inclut des contacts illimités."],
+                ['q' => "Monica est-elle vraiment open source ?", 'a' => [
+                    "Oui. Le code source de Monica est public, et le projet compte :count étoiles sur GitHub.",
+                    "Monica v3 sera publiée sous licence MIT.",
+                ], 'link' => ['label' => "En savoir plus sur Monica v3", 'page' => 'v3']],
+                ['q' => "L'auto-hébergement est-il gratuit ?", 'a' => "Monica ne facture pas le logiciel auto-hébergé. Le serveur et les frais d'infrastructure sont à votre charge."],
+                ['q' => "La version hébergée diffère-t-elle de la version auto-hébergée ?", 'a' => [
+                    "Elles utilisent la même application.",
+                    "Le service hébergé comprend l'infrastructure, les mises à jour gérées, les sauvegardes, la supervision, l'envoi d'e-mails et le support. Certaines intégrations qui dépendent de l'infrastructure opérée par Monica peuvent n'exister que sur le service hébergé.",
+                ]],
+                ['q' => "Puis-je passer de l'hébergé à l'auto-hébergé ?", 'a' => "Oui. Vous pouvez exporter vos données Monica et les importer dans une installation auto-hébergée compatible."],
+                ['q' => "Puis-je résilier à tout moment ?", 'a' => "Oui. Résiliez depuis les réglages de votre compte. Votre abonnement reste actif jusqu'à la fin de la période en cours."],
+                ['q' => "Y a-t-il des frais de résiliation ?", 'a' => "Non. Partir ne devrait pas exiger une rançon."],
+                ['q' => "Que se passe-t-il si mon paiement échoue ?", 'a' => [
+                    "Nous vous prévenons et réessayons le paiement avant de restreindre le compte.",
+                    "Vos données ne sont pas supprimées parce qu'une carte a expiré.",
+                ]],
+                ['q' => "Comment fonctionnent les remboursements ?", 'a' => [
+                    "Si vous avez été débité par erreur ou avez oublié de résilier, écrivez-nous dans les 30 jours. Nous examinerons la demande comme des êtres humains raisonnables.",
+                    "Les abonnements annuels peuvent être remboursés dans le délai défini par notre politique de remboursement. Les remboursements ne s'appliquent pas aux comptes ayant gravement abusé du service.",
+                ]],
+                ['q' => "Le prix va-t-il augmenter ?", 'a' => [
+                    "Les prix peuvent évoluer avec Monica, mais nous prévenons les abonnés existants à l'avance.",
+                    "Nous ne changeons pas les prix en silence en espérant que personne ne s'en aperçoive.",
+                ]],
+                ['q' => "Les taxes sont-elles incluses ?", 'a' => "Les prix affichés incluent ou excluent les taxes selon votre pays et la loi applicable. Le montant final est indiqué avant le paiement."],
+                ['q' => "Monica conserve-t-elle mes informations de paiement ?", 'a' => "Les informations de paiement sont traitées par notre prestataire. Monica ne stocke pas les numéros de carte complets."],
+                ['q' => "Mes données servent-elles à la publicité ?", 'a' => "Non. Monica ne vend pas vos données personnelles, n'affiche pas de publicité et n'utilise pas les personnes de votre compte pour construire des profils publicitaires."],
+                ['q' => "Mes données servent-elles à entraîner des modèles d'IA ?", 'a' => "Aucun modèle n'est entraîné sur le contenu privé de votre compte Monica."],
+                ['q' => "Les sauvegardes sont-elles incluses ?", 'a' => [
+                    "Oui, le service hébergé comprend des sauvegardes gérées.",
+                    "Les installations auto-hébergées exigent que vous configuriez et testiez vos propres sauvegardes.",
+                ]],
+                ['q' => "Puis-je tout exporter ?", 'a' => "Vous pouvez exporter contacts, relations, notes, rappels, activités, champs personnalisés et les autres données prises en charge. Les pièces jointes sont incluses selon le format d'export documenté."],
+                ['q' => "Puis-je supprimer mon compte ?", 'a' => "Oui. La suppression du compte se fait depuis les réglages, sans passer par le support."],
+                ['q' => "Proposez-vous des réductions ?", 'a' => "Pas pour l'instant. Nous préférons un prix compréhensible à un système où chacun négocie de son côté."],
+                ['q' => "Proposez-vous une offre à vie ?", 'a' => "Non. Les serveurs continuent d'avoir des dépenses après la fin des campagnes de lancement enthousiastes."],
+                ['q' => "Proposez-vous une offre entreprise ?", 'a' => [
+                    "Aucun rendez-vous commercial n'est nécessaire pour utiliser Monica.",
+                    "Pour les questions de sécurité, d'achats ou d'hébergement en volume, écrivez-nous.",
+                ]],
+                ['q' => "Puis-je payer dans une autre devise ?", 'a' => "La facturation se fait actuellement en USD. Votre banque peut convertir le montant et facturer des frais de change."],
+                ['q' => "S'abonner soutient-il le projet open source ?", 'a' => "Oui. Les abonnements hébergés financent l'infrastructure, la maintenance, le support et le développement open source continu de Monica."],
+            ],
+        ],
+
+        'finalCta' => [
+            'title' => "Votre mémoire a fait assez d'heures non payées.",
+            'body' => "Prenez la version hébergée et laissez-nous gérer l'infrastructure, ou installez Monica sur votre propre serveur.",
+            'body2' => "Dans les deux cas, vos contacts restent des gens, pas des prospects.",
+            'primaryCta' => "Commencer avec Monica",
+            'secondaryCta' => "Auto-héberger Monica",
+            'note' => "Une offre hébergée simple · Auto-hébergement gratuit · Open source",
+        ],
     ],
 
     'footer' => [

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,8 @@
   "packages": {
     "": {
       "dependencies": {
-        "@tailwindcss/vite": "^4.1.8"
+        "@tailwindcss/vite": "^4.1.8",
+        "alpinejs": "^3.15.12"
       },
       "devDependencies": {
         "@tighten/jigsaw-vite-plugin": "^1.0.1",
@@ -1150,6 +1151,30 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.1.5.tgz",
+      "integrity": "sha512-1tdfLmNjWG6t/CsPldh+foumYFo3cpyCHgBYQ34ylaMsJ+SNHQ1kApMIa8jN+i593zQuaw3AdWH0nJTARzCFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.1.5"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.5.tgz",
+      "integrity": "sha512-oJ4F3TnvpXaQwZJNF3ZK+kLPHKarDmJjJ6jyzVNDKH9md1dptjC7lWR//jrGuLdek/U6iltWxqAnYOu8gCiOvA==",
+      "license": "MIT"
+    },
+    "node_modules/alpinejs": {
+      "version": "3.15.12",
+      "resolved": "https://registry.npmjs.org/alpinejs/-/alpinejs-3.15.12.tgz",
+      "integrity": "sha512-nJvPAQVNPdZZ0NrExJ/kzQco3ijR8LwvCOadQecllESiqT4NyZ/57sN9V2XyvhlBGAbmlKYgeWZvYdKq99ij/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "~3.1.1"
+      }
     },
     "node_modules/async": {
       "version": "1.5.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "vite": "^6.4.2"
   },
   "dependencies": {
-    "@tailwindcss/vite": "^4.1.8"
+    "@tailwindcss/vite": "^4.1.8",
+    "alpinejs": "^3.15.12"
   }
 }

--- a/source/_assets/js/app.js
+++ b/source/_assets/js/app.js
@@ -1,0 +1,14 @@
+/* The site's only JavaScript.
+ *
+ * Alpine drives the billing toggle on the pricing page and nothing else. It is
+ * loaded as a module, so it is deferred and runs after the document is parsed.
+ *
+ * Everything Alpine touches is server-rendered in its default state first, so
+ * the page is correct and readable before this file arrives, and still correct
+ * if it never does. Keep it that way: bind with `x-text` over real content
+ * rather than rendering an empty element and filling it in. */
+import Alpine from 'alpinejs';
+
+window.Alpine = Alpine;
+
+Alpine.start();

--- a/source/_layouts/base.blade.php
+++ b/source/_layouts/base.blade.php
@@ -4,6 +4,10 @@
     Pages set two front-matter values, `locale` and `page`, and everything else
     follows from them: the language of the copy, the canonical URL, and the
     hreflang links to the other three translations.
+
+    A page that needs Alpine adds a third, `alpine: true`. Most do not, and
+    should not: the script is 16KB over the wire and a page that ships it
+    without using it is paying for nothing.
 --}}
 <!DOCTYPE html>
 <html lang="{{ $page->locale }}">
@@ -18,6 +22,21 @@
 
         @viteRefresh()
         <link rel="stylesheet" href="{{ vite('source/_assets/css/main.css') }}">
+
+        @if ($page->alpine ?? false)
+            {{-- A module, so it is deferred and runs after parsing. Everything
+                 it enhances is server-rendered in its default state first. --}}
+            <script type="module" src="{{ vite('source/_assets/js/app.js') }}"></script>
+
+            {{-- Controls that only do something once Alpine is running carry
+                 `js-only`, so they are not offered to a reader who will not get
+                 it. Declared here rather than in the stylesheet, because a
+                 <noscript> block is the only way to ask about JavaScript in
+                 CSS, and alongside the script so the two cannot drift apart. --}}
+            <noscript>
+                <style>.js-only { display: none !important }</style>
+            </noscript>
+        @endif
     </head>
 
     <body class="min-h-screen bg-canvas font-sans text-text">

--- a/source/_partials/faq.blade.php
+++ b/source/_partials/faq.blade.php
@@ -1,0 +1,46 @@
+{{--
+    A list of questions as native disclosures: keyboard-operable, findable with
+    the browser's own find-in-page, and readable with JavaScript off.
+
+    `a` is one paragraph or several. Pricing answers often need two, so the
+    string form is cast rather than duplicated as a second key.
+
+    An item may also carry `link`, a label plus a route key, for answers that
+    are better finished by the page that covers them in full.
+
+    @include('_partials.faq', ['title' => $page->t('faq.title'), 'items' => $page->t('faq.items')])
+--}}
+<section class="border-t border-border">
+    <div class="mx-auto w-full max-w-marketing px-4 py-section-sm md:px-8 lg:py-section">
+        <h2 class="text-heading font-semibold lg:text-display-md">{{ $title }}</h2>
+
+        <div class="mt-8 max-w-[820px] border-t border-border">
+            @foreach ($items as $item)
+                <details class="group border-b border-border-subtle">
+                    <summary class="flex cursor-pointer list-none items-center gap-4 py-5 text-title font-semibold [&::-webkit-details-marker]:hidden">
+                        <span>{{ $item['q'] }}</span>
+                        <span aria-hidden="true" class="ml-auto font-mono text-[18px] font-normal text-text-muted">
+                            <span class="group-open:hidden">+</span>
+                            <span class="hidden group-open:inline">&ndash;</span>
+                        </span>
+                    </summary>
+                    <div class="pb-5">
+                        @foreach ((array) $item['a'] as $paragraph)
+                            <p class="mt-3 max-w-[70ch] text-copy text-text-secondary text-pretty first:mt-0">{{ $paragraph }}</p>
+                        @endforeach
+
+                        @isset($item['link'])
+                            <a
+                                href="{{ $page->route($item['link']['page']) }}"
+                                class="mt-3 inline-flex items-center gap-2 text-copy text-accent underline-offset-[3px]"
+                            >
+                                {{ $item['link']['label'] }}
+                                @include('_partials.icon', ['name' => 'arrowRight', 'size' => 14])
+                            </a>
+                        @endisset
+                    </div>
+                </details>
+            @endforeach
+        </div>
+    </div>
+</section>

--- a/source/_partials/home/faq.blade.php
+++ b/source/_partials/home/faq.blade.php
@@ -1,36 +1,4 @@
-<section class="border-t border-border">
-    <div class="mx-auto w-full max-w-marketing px-4 py-section-sm md:px-8 lg:py-section">
-        <h2 class="text-heading font-semibold lg:text-display-md">{{ $page->t('faq.title') }}</h2>
-
-        {{-- Native disclosure: keyboard-operable and readable with JavaScript off. --}}
-        <div class="mt-8 max-w-[820px] border-t border-border">
-            @foreach ($page->t('faq.items') as $item)
-                <details class="group border-b border-border-subtle">
-                    <summary class="flex cursor-pointer list-none items-center gap-4 py-5 text-title font-semibold [&::-webkit-details-marker]:hidden">
-                        <span>{{ $item['q'] }}</span>
-                        <span aria-hidden="true" class="ml-auto font-mono text-[18px] font-normal text-text-muted">
-                            <span class="group-open:hidden">+</span>
-                            <span class="hidden group-open:inline">&ndash;</span>
-                        </span>
-                    </summary>
-                    <div class="pb-5">
-                        <p class="max-w-[70ch] text-copy text-text-secondary text-pretty">{{ $item['a'] }}</p>
-
-                        {{-- An answer may point at the page that covers it in
-                             full. `page` is a route key, so the link stays in
-                             the reader's language. --}}
-                        @isset($item['link'])
-                            <a
-                                href="{{ $page->route($item['link']['page']) }}"
-                                class="mt-3 inline-flex items-center gap-2 text-copy text-accent underline-offset-[3px]"
-                            >
-                                {{ $item['link']['label'] }}
-                                @include('_partials.icon', ['name' => 'arrowRight', 'size' => 14])
-                            </a>
-                        @endisset
-                    </div>
-                </details>
-            @endforeach
-        </div>
-    </div>
-</section>
+@include('_partials.faq', [
+    'title' => $page->t('faq.title'),
+    'items' => $page->t('faq.items'),
+])

--- a/source/_partials/pricing/compare.blade.php
+++ b/source/_partials/pricing/compare.blade.php
@@ -1,0 +1,38 @@
+@php
+    $cell = 'border-b border-border-subtle px-2 py-3 text-left align-top text-small md:px-4 md:py-4 md:text-copy';
+@endphp
+
+<section class="border-t border-border bg-surface-subtle">
+    <div class="mx-auto w-full max-w-marketing px-4 py-section-sm md:px-8 lg:py-section">
+        <h2 class="text-heading font-semibold lg:text-display-md">{{ $page->t('pricing.compare.title') }}</h2>
+
+        {{-- Narrow screens scroll the table rather than crushing three columns
+             into unreadable widths. --}}
+        <div class="mt-8 overflow-x-auto">
+            <table class="w-full border-collapse">
+                <thead>
+                    <tr>
+                        <th scope="col" class="{{ $cell }} border-b-border text-micro font-medium tracking-[0.06em] text-text-muted uppercase">
+                            <span class="sr-only">{{ $page->t('pricing.compare.rowHeader') }}</span>
+                        </th>
+                        <th scope="col" class="{{ $cell }} border-b-border text-micro font-medium tracking-[0.06em] text-text-muted uppercase">
+                            {{ $page->t('pricing.compare.hosted') }}
+                        </th>
+                        <th scope="col" class="{{ $cell }} border-b-border text-micro font-medium tracking-[0.06em] text-text-muted uppercase">
+                            {{ $page->t('pricing.compare.selfHosted') }}
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach ($page->t('pricing.compare.rows') as $row)
+                        <tr>
+                            <th scope="row" class="{{ $cell }} w-[34%] font-medium text-text lg:w-[30%]">{{ $row['label'] }}</th>
+                            <td class="{{ $cell }} text-text-secondary">{{ $row['hosted'] }}</td>
+                            <td class="{{ $cell }} text-text-secondary">{{ $row['selfHosted'] }}</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    </div>
+</section>

--- a/source/_partials/pricing/final-cta.blade.php
+++ b/source/_partials/pricing/final-cta.blade.php
@@ -1,0 +1,26 @@
+<section class="border-t border-border bg-surface-subtle">
+    <div class="mx-auto w-full max-w-form px-4 py-section-sm md:px-8 lg:py-section">
+        <h2 class="text-heading font-semibold lg:text-display-md">{{ $page->t('pricing.finalCta.title') }}</h2>
+
+        <p class="mt-5 text-copy-lg text-text-secondary text-pretty">{{ $page->t('pricing.finalCta.body') }}</p>
+        <p class="mt-4 text-copy-lg text-text-secondary text-pretty">{{ $page->t('pricing.finalCta.body2') }}</p>
+
+        <div class="mt-8 flex flex-wrap gap-3 max-md:flex-col max-md:items-stretch">
+            <a href="{{ $page->links['getStarted'] }}" class="mn-btn mn-btn--primary no-underline hover:no-underline max-md:w-full">
+                {{ $page->t('pricing.finalCta.primaryCta') }}
+            </a>
+            <a href="{{ $page->links['selfHost'] }}" class="mn-btn mn-btn--secondary no-underline hover:no-underline max-md:w-full">
+                {{ $page->t('pricing.finalCta.secondaryCta') }}
+            </a>
+        </div>
+
+        <p class="mt-5 font-mono text-mono text-text-muted">{{ $page->t('pricing.finalCta.note') }}</p>
+    </div>
+</section>
+
+{{-- The legal footnote sits outside the CTA band, quiet and last. --}}
+<div class="border-t border-border">
+    <div class="mx-auto w-full max-w-marketing px-4 py-5 md:px-8">
+        <p class="font-mono text-mono text-text-muted">{{ $page->t('pricing.taxFootnote') }}</p>
+    </div>
+</div>

--- a/source/_partials/pricing/leaving.blade.php
+++ b/source/_partials/pricing/leaving.blade.php
@@ -1,0 +1,23 @@
+<section class="border-t border-border">
+    <div class="mx-auto w-full max-w-marketing px-4 py-section-sm md:px-8 lg:py-section">
+        <h2 class="text-heading font-semibold lg:text-display-md">{{ $page->t('pricing.leaving.title') }}</h2>
+
+        <p class="mt-5 max-w-[62ch] text-copy-lg text-text-secondary text-pretty">{{ $page->t('pricing.leaving.body') }}</p>
+        <p class="mt-4 max-w-[62ch] text-copy-lg text-text-secondary text-pretty">{{ $page->t('pricing.leaving.body2') }}</p>
+
+        {{-- The application's own row group, so the three steps look like the
+             settings screen the reader will actually use. --}}
+        <div class="mn-rowgroup mn-rowgroup--bordered mt-8 max-w-[820px]">
+            @foreach ($page->t('pricing.leaving.steps') as $step)
+                <div class="mn-row">
+                    <span class="mn-row__main">
+                        <span class="mn-row__label">{{ $step['label'] }}</span>
+                        <span class="mn-row__desc whitespace-normal">{{ $step['body'] }}</span>
+                    </span>
+                </div>
+            @endforeach
+        </div>
+
+        <p class="mt-5 font-mono text-mono text-text-muted">{{ $page->t('pricing.leaving.note') }}</p>
+    </div>
+</section>

--- a/source/_partials/pricing/no-charge.blade.php
+++ b/source/_partials/pricing/no-charge.blade.php
@@ -1,0 +1,16 @@
+<section class="border-t border-border bg-surface-subtle">
+    <div class="mx-auto w-full max-w-marketing px-4 py-section-sm md:px-8 lg:py-section">
+        <h2 class="text-heading font-semibold lg:text-display-md">{{ $page->t('pricing.noCharge.title') }}</h2>
+
+        {{-- Uniform rules: the column count is fluid, so a stronger rule on the
+             first row would only line up at one width. --}}
+        <div class="mt-10 grid grid-cols-[repeat(auto-fit,minmax(280px,1fr))] gap-x-6 gap-y-8">
+            @foreach ($page->t('pricing.noCharge.items') as $item)
+                <div class="border-t border-border pt-5">
+                    <h3 class="text-title font-semibold">{{ $item['title'] }}</h3>
+                    <p class="mt-2 text-copy text-text-secondary text-pretty">{{ $item['body'] }}</p>
+                </div>
+            @endforeach
+        </div>
+    </div>
+</section>

--- a/source/_partials/pricing/plans.blade.php
+++ b/source/_partials/pricing/plans.blade.php
@@ -1,0 +1,120 @@
+@php
+    $lede = 'max-w-[58ch] text-lede-sm text-text-secondary text-pretty md:text-lede-md lg:text-lede';
+    $body = 'text-copy text-text-secondary text-pretty';
+    $planCard = 'flex flex-col rounded-lg border border-border bg-surface p-region';
+    $planTitle = 'text-heading-sm font-semibold';
+    $amount = 'text-[44px] leading-none font-semibold tracking-[-0.03em]';
+
+    // The segmented control is two radios and two labels. The peers are named,
+    // because `peer-checked:` compiles to a `~` combinator that would match any
+    // later sibling: an unnamed peer lights both labels at once. The prices are
+    // not siblings of the inputs at all, so those swap through the section's
+    // `:has()` instead.
+    //
+    // Written out per label rather than built from a variable: Tailwind scans
+    // for literal class strings, and a concatenated one is invisible to it.
+    // The checked colour is marked important because `hover:text-text` ties with
+    // it on specificity and wins on source order. The pointer is left sitting on
+    // the label the moment it is clicked, so without this the selected option is
+    // near-black text on a near-black pill.
+    $seg = 'cursor-pointer rounded-full px-4 py-1.5 text-small text-text-secondary transition-colors duration-100 ease-standard hover:text-text';
+    $segYearly = 'peer-checked/yearly:bg-surface-inverse peer-checked/yearly:font-medium peer-checked/yearly:text-canvas! peer-focus-visible/yearly:outline-2 peer-focus-visible/yearly:outline-offset-2 peer-focus-visible/yearly:outline-focus';
+    $segMonthly = 'peer-checked/monthly:bg-surface-inverse peer-checked/monthly:font-medium peer-checked/monthly:text-canvas! peer-focus-visible/monthly:outline-2 peer-focus-visible/monthly:outline-offset-2 peer-focus-visible/monthly:outline-focus';
+@endphp
+
+{{-- `group/billing` is what the price spans read through `group-has-*`. --}}
+<section class="group/billing">
+    <div class="mx-auto w-full max-w-marketing px-4 py-section-sm md:px-8 lg:py-section">
+        <span class="font-mono text-mono text-text-muted">{{ $page->t('pricing.eyebrow') }}</span>
+
+        <h1 class="mt-4 text-display-sm font-semibold md:text-display-lg lg:text-display-xl">
+            {{ $page->t('pricing.title') }}
+        </h1>
+
+        <p class="mt-6 {{ $lede }}">{{ $page->t('pricing.lede') }}</p>
+        <p class="mt-4 {{ $lede }}">{{ $page->t('pricing.lede2') }}</p>
+
+        <div class="mt-8 flex flex-wrap items-center gap-4">
+            <fieldset class="inline-flex rounded-full border border-border bg-surface p-[3px]">
+                <legend class="sr-only">{{ $page->t('pricing.billing.label') }}</legend>
+
+                <input type="radio" name="billing" id="billing-yearly" class="peer/yearly sr-only" checked>
+                <label for="billing-yearly" class="{{ $seg }} {{ $segYearly }}">{{ $page->t('pricing.billing.yearly') }}</label>
+
+                <input type="radio" name="billing" id="billing-monthly" class="peer/monthly sr-only">
+                <label for="billing-monthly" class="{{ $seg }} {{ $segMonthly }}">{{ $page->t('pricing.billing.monthly') }}</label>
+            </fieldset>
+
+            <span class="font-mono text-mono text-text-muted">{{ $page->t('pricing.currency') }}</span>
+        </div>
+
+        <div class="mt-8 grid grid-cols-[repeat(auto-fit,minmax(320px,1fr))] gap-6">
+            <div class="{{ $planCard }}">
+                <h2 class="{{ $planTitle }}">{{ $page->t('pricing.hosted.title') }}</h2>
+                <p class="mt-2 {{ $body }}">{{ $page->t('pricing.hosted.body') }}</p>
+
+                {{-- Fixed height so the two cards' buttons stay on one line as
+                     the price swaps between a one-line and a two-line note. --}}
+                <div class="mt-6 min-h-24">
+                    <div class="flex items-baseline gap-3">
+                        <span class="{{ $amount }}">
+                            <span class="hidden group-has-[#billing-yearly:checked]/billing:inline">{{ $page->t('pricing.hosted.yearlyPrice') }}</span>
+                            <span class="hidden group-has-[#billing-monthly:checked]/billing:inline">{{ $page->t('pricing.hosted.monthlyPrice') }}</span>
+                        </span>
+                        <span class="text-copy-lg text-text-secondary">
+                            <span class="hidden group-has-[#billing-yearly:checked]/billing:inline">{{ $page->t('pricing.hosted.yearlyPeriod') }}</span>
+                            <span class="hidden group-has-[#billing-monthly:checked]/billing:inline">{{ $page->t('pricing.hosted.monthlyPeriod') }}</span>
+                        </span>
+                    </div>
+
+                    <p class="mt-3 {{ $body }}">
+                        <span class="hidden group-has-[#billing-yearly:checked]/billing:inline">{{ $page->t('pricing.hosted.yearlyNote') }}</span>
+                        <span class="hidden group-has-[#billing-monthly:checked]/billing:inline">{{ $page->t('pricing.hosted.monthlyNote') }}</span>
+                    </p>
+                    <p class="mt-2 font-mono text-mono text-text-muted">{{ $page->t('pricing.hosted.taxNote') }}</p>
+                </div>
+
+                <a href="{{ $page->links['getStarted'] }}" class="mn-btn mn-btn--primary mt-6 self-start no-underline hover:no-underline">
+                    {{ $page->t('pricing.hosted.cta') }}
+                </a>
+                <p class="mt-3 font-mono text-mono text-text-muted">{{ $page->t('pricing.hosted.trial') }}</p>
+
+                <p class="mt-8 text-copy font-medium text-text">{{ $page->t('pricing.hosted.listTitle') }}</p>
+                @include('_partials.bullets', ['items' => $page->t('pricing.hosted.items')])
+
+                <p class="mt-5 text-copy leading-[1.6] text-text-muted italic">{{ $page->t('pricing.hosted.aside') }}</p>
+                <p class="mt-6 border-t border-border-subtle pt-5 {{ $body }}">{{ $page->t('pricing.hosted.footnote') }}</p>
+            </div>
+
+            <div class="{{ $planCard }}">
+                <h2 class="{{ $planTitle }}">{{ $page->t('pricing.selfHosted.title') }}</h2>
+                <p class="mt-2 {{ $body }}">{{ $page->t('pricing.selfHosted.body') }}</p>
+
+                <div class="mt-6 min-h-24">
+                    <div class="flex items-baseline gap-3">
+                        <span class="{{ $amount }}">{{ $page->t('pricing.selfHosted.price') }}</span>
+                        <span class="text-copy-lg text-text-secondary">{{ $page->t('pricing.selfHosted.period') }}</span>
+                    </div>
+                    <p class="mt-3 text-copy leading-[1.6] text-text-muted italic">{{ $page->t('pricing.selfHosted.aside') }}</p>
+                </div>
+
+                <a href="{{ $page->links['selfHostingGuide'] }}" class="mn-btn mn-btn--secondary mt-6 self-start no-underline hover:no-underline">
+                    {{ $page->t('pricing.selfHosted.cta') }}
+                </a>
+                <p class="mt-3 text-small">
+                    <a href="{{ $page->links['github'] }}" class="text-accent underline-offset-[3px]">
+                        {{ $page->t('pricing.selfHosted.sourceCta', [':count' => $page->starCount]) }}
+                    </a>
+                </p>
+
+                <p class="mt-8 {{ $body }}">{{ $page->t('pricing.selfHosted.listTitle') }}</p>
+                @include('_partials.bullets', ['items' => $page->t('pricing.selfHosted.items')])
+
+                <p class="mt-6 border-t border-border-subtle pt-5 text-copy font-medium text-text text-pretty">
+                    {{ $page->t('pricing.selfHosted.footnote') }}
+                </p>
+                <p class="mt-3 {{ $body }}">{{ $page->t('pricing.selfHosted.footnote2') }}</p>
+            </div>
+        </div>
+    </div>
+</section>

--- a/source/_partials/pricing/plans.blade.php
+++ b/source/_partials/pricing/plans.blade.php
@@ -5,25 +5,35 @@
     $planTitle = 'text-heading-sm font-semibold';
     $amount = 'text-[44px] leading-none font-semibold tracking-[-0.03em]';
 
-    // The segmented control is two radios and two labels. The peers are named,
-    // because `peer-checked:` compiles to a `~` combinator that would match any
-    // later sibling: an unnamed peer lights both labels at once. The prices are
-    // not siblings of the inputs at all, so those swap through the section's
-    // `:has()` instead.
-    //
-    // Written out per label rather than built from a variable: Tailwind scans
-    // for literal class strings, and a concatenated one is invisible to it.
-    // The checked colour is marked important because `hover:text-text` ties with
-    // it on specificity and wins on source order. The pointer is left sitting on
-    // the label the moment it is clicked, so without this the selected option is
-    // near-black text on a near-black pill.
-    $seg = 'cursor-pointer rounded-full px-4 py-1.5 text-small text-text-secondary transition-colors duration-100 ease-standard hover:text-text';
-    $segYearly = 'peer-checked/yearly:bg-surface-inverse peer-checked/yearly:font-medium peer-checked/yearly:text-canvas! peer-focus-visible/yearly:outline-2 peer-focus-visible/yearly:outline-offset-2 peer-focus-visible/yearly:outline-focus';
-    $segMonthly = 'peer-checked/monthly:bg-surface-inverse peer-checked/monthly:font-medium peer-checked/monthly:text-canvas! peer-focus-visible/monthly:outline-2 peer-focus-visible/monthly:outline-offset-2 peer-focus-visible/monthly:outline-focus';
+    $seg = 'cursor-pointer rounded-full px-4 py-1.5 text-small transition-colors duration-100 ease-standard focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus';
+
+    /**
+     * Alpine's state, handed over as one JSON object rather than assembled in
+     * the markup, so the copy stays in lang/ and the template stays readable.
+     *
+     * `yearly` first, because it is the default the page renders with.
+     */
+    $billing = [
+        'period' => 'yearly',
+        'plans' => [
+            'yearly' => [
+                'price' => $page->t('pricing.hosted.yearlyPrice'),
+                'period' => $page->t('pricing.hosted.yearlyPeriod'),
+                'note' => $page->t('pricing.hosted.yearlyNote'),
+            ],
+            'monthly' => [
+                'price' => $page->t('pricing.hosted.monthlyPrice'),
+                'period' => $page->t('pricing.hosted.monthlyPeriod'),
+                'note' => $page->t('pricing.hosted.monthlyNote'),
+            ],
+        ],
+    ];
 @endphp
 
-{{-- `group/billing` is what the price spans read through `group-has-*`. --}}
-<section class="group/billing">
+{{-- The one interactive region on the site. Alpine owns the billing period;
+     everything below is rendered in the yearly state first, so the page is
+     complete and correct before the script loads, and if it never does. --}}
+<section x-data="{{ json_encode($billing, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) }}">
     <div class="mx-auto w-full max-w-marketing px-4 py-section-sm md:px-8 lg:py-section">
         <span class="font-mono text-mono text-text-muted">{{ $page->t('pricing.eyebrow') }}</span>
 
@@ -35,15 +45,26 @@
         <p class="mt-4 {{ $lede }}">{{ $page->t('pricing.lede2') }}</p>
 
         <div class="mt-8 flex flex-wrap items-center gap-4">
-            <fieldset class="inline-flex rounded-full border border-border bg-surface p-[3px]">
-                <legend class="sr-only">{{ $page->t('pricing.billing.label') }}</legend>
+            {{-- Hidden without JavaScript, because the buttons would be inert:
+                 the reader keeps the yearly price and loses only the choice,
+                 rather than being given a control that does nothing. --}}
+            <div class="js-only inline-flex rounded-full border border-border bg-surface p-[3px]" role="group" aria-label="{{ $page->t('pricing.billing.label') }}">
+                <button
+                    type="button"
+                    x-on:click="period = 'yearly'"
+                    x-bind:aria-pressed="period === 'yearly'"
+                    x-bind:class="period === 'yearly' ? 'bg-surface-inverse font-medium text-canvas' : 'text-text-secondary hover:text-text'"
+                    class="{{ $seg }}"
+                >{{ $page->t('pricing.billing.yearly') }}</button>
 
-                <input type="radio" name="billing" id="billing-yearly" class="peer/yearly sr-only" checked>
-                <label for="billing-yearly" class="{{ $seg }} {{ $segYearly }}">{{ $page->t('pricing.billing.yearly') }}</label>
-
-                <input type="radio" name="billing" id="billing-monthly" class="peer/monthly sr-only">
-                <label for="billing-monthly" class="{{ $seg }} {{ $segMonthly }}">{{ $page->t('pricing.billing.monthly') }}</label>
-            </fieldset>
+                <button
+                    type="button"
+                    x-on:click="period = 'monthly'"
+                    x-bind:aria-pressed="period === 'monthly'"
+                    x-bind:class="period === 'monthly' ? 'bg-surface-inverse font-medium text-canvas' : 'text-text-secondary hover:text-text'"
+                    class="{{ $seg }}"
+                >{{ $page->t('pricing.billing.monthly') }}</button>
+            </div>
 
             <span class="font-mono text-mono text-text-muted">{{ $page->t('pricing.currency') }}</span>
         </div>
@@ -55,22 +76,16 @@
 
                 {{-- Fixed height so the two cards' buttons stay on one line as
                      the price swaps between a one-line and a two-line note. --}}
-                <div class="mt-6 min-h-24">
+                {{-- Each binding wraps the yearly text it will replace, so the
+                     figures are in the HTML rather than filled in on load.
+                     aria-live keeps a screen reader informed when they change. --}}
+                <div class="mt-6 min-h-24" aria-live="polite">
                     <div class="flex items-baseline gap-3">
-                        <span class="{{ $amount }}">
-                            <span class="hidden group-has-[#billing-yearly:checked]/billing:inline">{{ $page->t('pricing.hosted.yearlyPrice') }}</span>
-                            <span class="hidden group-has-[#billing-monthly:checked]/billing:inline">{{ $page->t('pricing.hosted.monthlyPrice') }}</span>
-                        </span>
-                        <span class="text-copy-lg text-text-secondary">
-                            <span class="hidden group-has-[#billing-yearly:checked]/billing:inline">{{ $page->t('pricing.hosted.yearlyPeriod') }}</span>
-                            <span class="hidden group-has-[#billing-monthly:checked]/billing:inline">{{ $page->t('pricing.hosted.monthlyPeriod') }}</span>
-                        </span>
+                        <span class="{{ $amount }}" x-text="plans[period].price">{{ $page->t('pricing.hosted.yearlyPrice') }}</span>
+                        <span class="text-copy-lg text-text-secondary" x-text="plans[period].period">{{ $page->t('pricing.hosted.yearlyPeriod') }}</span>
                     </div>
 
-                    <p class="mt-3 {{ $body }}">
-                        <span class="hidden group-has-[#billing-yearly:checked]/billing:inline">{{ $page->t('pricing.hosted.yearlyNote') }}</span>
-                        <span class="hidden group-has-[#billing-monthly:checked]/billing:inline">{{ $page->t('pricing.hosted.monthlyNote') }}</span>
-                    </p>
+                    <p class="mt-3 {{ $body }}" x-text="plans[period].note">{{ $page->t('pricing.hosted.yearlyNote') }}</p>
                     <p class="mt-2 font-mono text-mono text-text-muted">{{ $page->t('pricing.hosted.taxNote') }}</p>
                 </div>
 

--- a/source/_partials/pricing/track-record.blade.php
+++ b/source/_partials/pricing/track-record.blade.php
@@ -1,0 +1,35 @@
+@php
+    // The star count is the only figure fetched at build time; the rest are
+    // fixed facts, so they live in lang/ with their labels.
+    $stats = [
+        ['value' => $page->starCount, 'label' => $page->t('pricing.trackRecord.starsLabel')],
+        ['value' => $page->t('pricing.trackRecord.since'), 'label' => $page->t('pricing.trackRecord.sinceLabel')],
+        ['value' => $page->t('pricing.trackRecord.launch'), 'label' => $page->t('pricing.trackRecord.launchLabel')],
+        ['value' => $page->t('pricing.trackRecord.featured'), 'label' => $page->t('pricing.trackRecord.featuredLabel')],
+    ];
+@endphp
+
+<section class="border-t border-border bg-surface-subtle">
+    <div class="mx-auto w-full max-w-marketing px-4 py-section-sm md:px-8 lg:py-section">
+        <h2 class="text-heading font-semibold lg:text-display-md">{{ $page->t('pricing.trackRecord.title') }}</h2>
+
+        <p class="mt-5 max-w-[62ch] text-copy-lg text-text-secondary text-pretty">{{ $page->t('pricing.trackRecord.body') }}</p>
+        <p class="mt-4 max-w-[62ch] text-copy-lg text-text-secondary text-pretty">
+            {{ $page->t('pricing.trackRecord.body2', [':count' => $page->starCount]) }}
+        </p>
+
+        <div class="mt-10 grid grid-cols-[repeat(auto-fit,minmax(220px,1fr))] gap-8">
+            @foreach ($stats as $stat)
+                <div>
+                    <div class="text-heading font-semibold text-pretty">{{ $stat['value'] }}</div>
+                    <div class="mt-2 font-mono text-mono text-text-muted">{{ $stat['label'] }}</div>
+                </div>
+            @endforeach
+        </div>
+
+        <a href="{{ $page->links['github'] }}" class="mn-btn mn-btn--secondary mt-8 gap-2 no-underline hover:no-underline">
+            @include('_partials.icon', ['name' => 'star'])
+            <span>{{ $page->t('pricing.trackRecord.cta') }}</span>
+        </a>
+    </div>
+</section>

--- a/source/_partials/pricing/why-pay.blade.php
+++ b/source/_partials/pricing/why-pay.blade.php
@@ -1,0 +1,16 @@
+<section class="border-t border-border">
+    <div class="mx-auto w-full max-w-form px-4 py-section-sm md:px-8 lg:py-section">
+        <h2 class="text-heading font-semibold lg:text-display-md">{{ $page->t('pricing.whyPay.title') }}</h2>
+
+        <p class="mt-5 text-copy-lg text-text-secondary text-pretty">{{ $page->t('pricing.whyPay.body') }}</p>
+        <p class="mt-4 text-copy-lg text-text-secondary text-pretty">{{ $page->t('pricing.whyPay.body2') }}</p>
+
+        {{-- The one claim the whole page rests on, so it gets the rule and the
+             larger type rather than a heading it does not deserve. --}}
+        <p class="mt-8 border-l-2 border-text pl-6 text-heading-sm font-semibold text-pretty">
+            {{ $page->t('pricing.whyPay.quote') }}
+        </p>
+
+        <p class="mt-6 text-copy leading-[1.6] text-text-muted italic">{{ $page->t('pricing.whyPay.aside') }}</p>
+    </div>
+</section>

--- a/source/_partials/site-footer.blade.php
+++ b/source/_partials/site-footer.blade.php
@@ -5,7 +5,7 @@
             'links' => [
                 ['label' => $page->t('nav.product'), 'href' => $page->route('home')],
                 ['label' => $page->t('nav.v3'), 'href' => $page->route('v3')],
-                ['label' => $page->t('nav.pricing'), 'href' => '#pricing'],
+                ['label' => $page->t('nav.pricing'), 'href' => $page->route('pricing')],
             ],
         ],
         [

--- a/source/_partials/site-header.blade.php
+++ b/source/_partials/site-header.blade.php
@@ -7,7 +7,7 @@
     $navItems = [
         ['label' => $page->t('nav.product'), 'href' => $home, 'current' => 'home'],
         ['label' => $page->t('nav.v3'), 'href' => $page->route('v3'), 'current' => 'v3'],
-        ['label' => $page->t('nav.pricing'), 'href' => '#pricing'],
+        ['label' => $page->t('nav.pricing'), 'href' => $page->route('pricing'), 'current' => 'pricing'],
         ['label' => $page->t('nav.openSource'), 'href' => '#open-source'],
         ['label' => $page->t('nav.blog'), 'href' => $page->links['blog']],
         ['label' => $page->t('nav.docs'), 'href' => $page->links['docs']],

--- a/source/de/preise.blade.php
+++ b/source/de/preise.blade.php
@@ -1,6 +1,7 @@
 ---
 locale: de
 page: pricing
+alpine: true
 ---
 @extends('_layouts.base')
 

--- a/source/de/preise.blade.php
+++ b/source/de/preise.blade.php
@@ -1,0 +1,19 @@
+---
+locale: de
+page: pricing
+---
+@extends('_layouts.base')
+
+@section('body')
+    @include('_partials.pricing.plans')
+    @include('_partials.pricing.compare')
+    @include('_partials.pricing.why-pay')
+    @include('_partials.pricing.no-charge')
+    @include('_partials.pricing.leaving')
+    @include('_partials.pricing.track-record')
+    @include('_partials.faq', [
+        'title' => $page->t('pricing.faq.title'),
+        'items' => $page->t('pricing.faq.items', [':count' => $page->starCount]),
+    ])
+    @include('_partials.pricing.final-cta')
+@endsection

--- a/source/en/pricing.blade.php
+++ b/source/en/pricing.blade.php
@@ -1,0 +1,19 @@
+---
+locale: en
+page: pricing
+---
+@extends('_layouts.base')
+
+@section('body')
+    @include('_partials.pricing.plans')
+    @include('_partials.pricing.compare')
+    @include('_partials.pricing.why-pay')
+    @include('_partials.pricing.no-charge')
+    @include('_partials.pricing.leaving')
+    @include('_partials.pricing.track-record')
+    @include('_partials.faq', [
+        'title' => $page->t('pricing.faq.title'),
+        'items' => $page->t('pricing.faq.items', [':count' => $page->starCount]),
+    ])
+    @include('_partials.pricing.final-cta')
+@endsection

--- a/source/en/pricing.blade.php
+++ b/source/en/pricing.blade.php
@@ -1,6 +1,7 @@
 ---
 locale: en
 page: pricing
+alpine: true
 ---
 @extends('_layouts.base')
 

--- a/source/es/precios.blade.php
+++ b/source/es/precios.blade.php
@@ -1,0 +1,19 @@
+---
+locale: es
+page: pricing
+---
+@extends('_layouts.base')
+
+@section('body')
+    @include('_partials.pricing.plans')
+    @include('_partials.pricing.compare')
+    @include('_partials.pricing.why-pay')
+    @include('_partials.pricing.no-charge')
+    @include('_partials.pricing.leaving')
+    @include('_partials.pricing.track-record')
+    @include('_partials.faq', [
+        'title' => $page->t('pricing.faq.title'),
+        'items' => $page->t('pricing.faq.items', [':count' => $page->starCount]),
+    ])
+    @include('_partials.pricing.final-cta')
+@endsection

--- a/source/es/precios.blade.php
+++ b/source/es/precios.blade.php
@@ -1,6 +1,7 @@
 ---
 locale: es
 page: pricing
+alpine: true
 ---
 @extends('_layouts.base')
 

--- a/source/fr/tarifs.blade.php
+++ b/source/fr/tarifs.blade.php
@@ -1,0 +1,19 @@
+---
+locale: fr
+page: pricing
+---
+@extends('_layouts.base')
+
+@section('body')
+    @include('_partials.pricing.plans')
+    @include('_partials.pricing.compare')
+    @include('_partials.pricing.why-pay')
+    @include('_partials.pricing.no-charge')
+    @include('_partials.pricing.leaving')
+    @include('_partials.pricing.track-record')
+    @include('_partials.faq', [
+        'title' => $page->t('pricing.faq.title'),
+        'items' => $page->t('pricing.faq.items', [':count' => $page->starCount]),
+    ])
+    @include('_partials.pricing.final-cta')
+@endsection

--- a/source/fr/tarifs.blade.php
+++ b/source/fr/tarifs.blade.php
@@ -1,6 +1,7 @@
 ---
 locale: fr
 page: pricing
+alpine: true
 ---
 @extends('_layouts.base')
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,11 +2,12 @@ import jigsaw from '@tighten/jigsaw-vite-plugin';
 import { defineConfig } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
 
-// The site ships no JavaScript. CSS is the only entry point.
+// Two entry points: the stylesheet, and the site's single script (Alpine, for
+// the pricing page's billing toggle). Templates resolve both through `vite()`.
 export default defineConfig({
     plugins: [
         jigsaw({
-            input: ['source/_assets/css/main.css'],
+            input: ['source/_assets/css/main.css', 'source/_assets/js/app.js'],
             refresh: true,
         }),
         tailwindcss(),


### PR DESCRIPTION
Builds `/pricing` in all four languages from the **Pricing** design in the Monica design project.

| Locale | URL |
| :--- | :--- |
| English | `/en/pricing/` |
| French | `/fr/tarifs/` |
| German | `/de/preise/` |
| Spanish | `/es/precios/` |

Slugs are translated, so hreflang and the sitemap carry `/fr/tarifs/` against `/en/pricing/` rather than a single English path.

## The page

Nine sections, following the design: the two plans with a billing toggle, the hosted vs self-hosted comparison table, why a subscription exists when the code is free, what is never charged for, what happens when a subscription ends, the project's track record, 23 questions about paying, and a closing CTA above the tax footnote.

## Alpine, for the billing toggle

**This adds the first JavaScript and the first runtime dependency to the site**, so the setup is deliberately narrow:

- **One entry point.** `source/_assets/js/app.js` starts Alpine and does nothing else. Loaded as a module, so it is deferred.
- **Loaded only where used.** A page opts in with `alpine: true` in its front matter. Only the four pricing pages do, so the homepage and the v3 page do not pay 16KB (gzipped) for a script they never call. Verified in the build: 4 pages load it, 10 do not.
- **Server-rendered first.** The bindings wrap the yearly figures rather than filling in empty elements: `<span x-text="plans[period].price">$90</span>`. The prices are in the HTML and stay correct if the script never arrives.
- **No dead controls.** The toggle carries `js-only`, hidden inside a `<noscript>` block in the layout. Without JavaScript the reader keeps the yearly price and loses only the choice, rather than being handed two buttons that do nothing.
- **No copy in expressions.** State is one `json_encode` of the lang strings into `x-data`, so translations stay in `lang/` and the accented locales survive the round trip.

The price block gained `aria-live="polite"`, since the figures now change under the reader rather than on navigation.

## Two changes outside the page

**`t()` now fills placeholders at every depth.** It previously ran `strtr` only when the value was a bare string, so a `:count` inside a FAQ answer, which is a list of paragraphs, reached the rendered page literally. Verified: no `:count` survives anywhere in the build.

That fix also exposed a copy bug worth naming, since `starCount` already carries its own `+`: "the project has **more than** 24k+ stars" now reads "the project has 24k+ stars", in all four locales.

**The FAQ markup moved to `_partials/faq.blade.php`**, taking `title` and `items`, because the pricing FAQ needs the same disclosure behaviour with multi-paragraph answers. `a` may now be one string or a list. `_partials/home/faq.blade.php` delegates to it and renders unchanged (still 9 disclosures, still 7 `/v3/` links on the homepage).

The header and footer resolve `route('pricing')` in place of the design's `#pricing` anchor, and the header marks the page as current.

## Verification

- `npm run build` clean; 4 new pages, all 4 in the sitemap with correct per-locale slugs in `hreflang`.
- Translation key shapes match across locales (573 keys each).
- The rendered `x-data` attribute decodes to valid JSON in all four locales, accents intact.
- Every Alpine expression in the built HTML was extracted and evaluated in Node against that state, in both periods and all four locales: prices, periods, notes and both `:class` branches resolve correctly, and the click handlers mutate `period`.
- Server-rendered default matches the `x-data` default on every locale, so the no-JS view is right.
- Alpine's full directive set is present in the bundle; no `x-*` attribute, `js-only` marker or script tag leaks onto a non-pricing page.
- Checked earlier at a 591px viewport in French and German: no horizontal page scroll, no element wider than the viewport.

## Worth your eye

**The prices are the design's** (`$9` / month, `$90` / year, 30-day trial, USD only) and are repeated in the FAQ answers. They are product claims rather than layout, so I have carried them across as written rather than editing them. They live in `lang/<locale>.php` under `pricing.hosted.*` if any are wrong.

Two links have no destination yet and use the existing placeholders: the retention policy and the refund policy are named in the copy but not linked, since there is no page to point at.