### PR TITLE
feat: add an RSS feed for the blog

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -136,6 +136,7 @@ Partials take data through the `@include` array: `@include('_partials.icon', ['n
 | Blog posts                          | `source/_posts/` (Markdown), images in `source/assets/images/blog/` |
 | Blog templates                      | `source/_layouts/post.blade.php`, `source/_partials/blog/` |
 | Blog post body styling              | `source/_assets/css/prose.css`                      |
+| Blog RSS feed                       | `source/_partials/blog/feed.blade.php`, `source/<locale>/blog/feed.blade.xml` |
 | Copy                                | `lang/<locale>.php`                                 |
 | Routes, helpers, links, locales     | `config.php`                                        |
 | Production domain                   | `config.production.php`                             |
@@ -199,6 +200,10 @@ The homepage, pricing, the v3 teaser and the blog exist. Features and docs are u
 **Dates are timestamps.** YAML reads an unquoted `date: 2018-10-12` as a date and hands it back as ten digits, so anything that displays a date or gives one to a crawler calls `$post->isoDate()`. `readingMinutes()` and `authorInitials()` are collection helpers alongside it.
 
 `.mn-prose` in `source/_assets/css/prose.css` styles the rendered Markdown. It is the one place on the site that styles by element rather than by class, because the markup is generated and there is nothing to hang a utility on. Nothing else belongs in that file.
+
+**The feed** is RSS 2.0 at `/<locale>/blog/feed.xml`, the 20 newest posts with their full bodies. `feedContent()` rewrites every `src` and `href` to an absolute URL first, because a feed is read on someone else's host and root-relative markup resolves against that host instead of ours. `rfcDate()` exists because RSS accepts only RFC 2822 dates. `lastBuildDate` is the newest post's date rather than the build's, so rebuilding the site does not tell every reader the feed changed.
+
+Autodiscovery (`rel="alternate" type="application/rss+xml"`) is in `_layouts/base.blade.php`, so it is on every page rather than only the blog: the page someone is on when they decide to subscribe is rarely the index. It points at the current locale's feed. That is safe under Turbo for the same reason `<html lang>` is: the link is identical across a locale, and crossing locales is a full page load because the locale picker carries `data-turbo="false"`.
 
 Posts have no categories: the two the old site used were dropped on import. Adding a post means a Markdown file in `source/_posts/` with `title`, `slug`, `date`, `author` and `description`, and nothing else to register.
 

--- a/config.php
+++ b/config.php
@@ -61,6 +61,14 @@ return [
             'perPage' => 10,
             'prefix' => 'page',
 
+            /**
+             * How many posts the feed carries. Ours is not paginated, so this
+             * is the whole of it: a reader subscribing today gets the last two
+             * years and picks up the rest from the site. Every item carries its
+             * full body, so the number is also what keeps the file reasonable.
+             */
+            'perFeed' => 20,
+
             /** Names the SEO shape in _partials/seo.blade.php, as `page` does elsewhere. */
             'page' => 'post',
 
@@ -91,6 +99,31 @@ return [
                 return is_numeric($post->date)
                     ? date('Y-m-d', (int) $post->date)
                     : (string) $post->date;
+            },
+
+            /** The same date as RFC 2822, which is the only format RSS accepts. */
+            'rfcDate' => function ($post) {
+                $timestamp = is_numeric($post->date) ? (int) $post->date : strtotime((string) $post->date);
+
+                return date(DATE_RSS, $timestamp);
+            },
+
+            /**
+             * The post body, with every URL made absolute, for the feed.
+             *
+             * A feed is read somewhere else: in a reader, in an email digest,
+             * on another domain. Root-relative markup that resolves perfectly
+             * on the site resolves against whatever host is displaying it,
+             * which is how a feed ends up full of broken screenshots. Both
+             * `src` and `href` are rewritten, so images and internal links
+             * survive the trip.
+             */
+            'feedContent' => function ($post) {
+                return preg_replace_callback(
+                    '/\b(src|href)="(\/[^"]*)"/',
+                    fn ($match) => $match[1] . '="' . $post->absolute($match[2]) . '"',
+                    $post->getContent(),
+                );
             },
 
             /** "Regis Freyd" becomes "RF", for the avatar circle. */
@@ -294,6 +327,15 @@ return [
     /** A single post: /fr/blog/life-events/. */
     'postPath' => function ($page, string $slug, ?string $locale = null) {
         return $page->localePath('blog', $locale ?: $page->lang()) . "{$slug}/";
+    },
+
+    /**
+     * The RSS feed: /fr/blog/feed.xml. One per locale, like everything else
+     * here, so a reader who subscribes from the French blog gets a feed whose
+     * links land back on the French pages.
+     */
+    'feedPath' => function ($page, ?string $locale = null) {
+        return $page->blogPath($locale) . 'feed.xml';
     },
 
     /**

--- a/source/_layouts/base.blade.php
+++ b/source/_layouts/base.blade.php
@@ -14,6 +14,19 @@
         <link rel="icon" href="/favicon.ico">
         <link rel="sitemap" href="/sitemap.xml">
 
+        {{-- How a feed reader finds the feed: you paste any page of the site
+             into it and it looks here. On every page rather than only the blog,
+             because the page somebody happens to be standing on when they
+             decide to subscribe is rarely the index. It points at the current
+             locale's feed, so a reader browsing in French subscribes in
+             French. --}}
+        <link
+            rel="alternate"
+            type="application/rss+xml"
+            title="{{ $page->t('meta.blog.title') }}"
+            href="{{ $page->absolute($page->feedPath()) }}"
+        >
+
         @include('_partials.seo')
 
         @viteRefresh()

--- a/source/_partials/blog/feed.blade.php
+++ b/source/_partials/blog/feed.blade.php
@@ -1,0 +1,58 @@
+{{--
+    The blog's RSS feed, shared by all four locale templates.
+
+    RSS 2.0 rather than Atom, because it is what "RSS feed" means to almost
+    everyone and every reader accepts it. Two namespaces earn their place:
+    `content` carries the full post body, which `description` is not allowed to
+    do, and `dc` carries an author name, which RSS's own `author` element cannot
+    without an email address attached.
+
+    Full bodies rather than summaries. These posts are short, the images are
+    the point of half of them, and a feed that makes you click through to read
+    two paragraphs is a feed nobody keeps subscribed to.
+
+    Included from source/<locale>/blog/feed.blade.xml, which is front matter
+    and one line, so the four cannot drift apart.
+--}}
+@php
+    $items = $posts->sortByDesc('date')->take($page->collections->posts->perFeed);
+
+    // The feed's own address, which `atom:link rel="self"` exists to state.
+    // Without it a reader that has been handed the file by some other route
+    // has no way to know where to look for the next one.
+    $self = $page->absolute($page->feedPath());
+
+    // The newest post's date, not the build's. A feed that changes its
+    // timestamp every time the site is rebuilt teaches readers to ignore it.
+    $updated = $items->first()?->rfcDate();
+@endphp
+{{-- Echoed, because a literal <?xml would be parsed as a PHP open tag. --}}
+{!! '<'.'?xml version="1.0" encoding="UTF-8"?'.'>' !!}
+<rss version="2.0"
+     xmlns:atom="http://www.w3.org/2005/Atom"
+     xmlns:content="http://purl.org/rss/1.0/modules/content/"
+     xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <channel>
+        <title>{{ $page->t('meta.blog.title') }}</title>
+        <link>{{ $page->absolute($page->blogPath()) }}</link>
+        <description>{{ $page->t('meta.blog.description') }}</description>
+        <language>{{ $page->locale }}</language>
+        <atom:link href="{{ $self }}" rel="self" type="application/rss+xml"/>
+@if ($updated)
+        <lastBuildDate>{{ $updated }}</lastBuildDate>
+@endif
+@foreach ($items as $post)
+        <item>
+            <title>{{ $post->title }}</title>
+            <link>{{ $page->absolute($page->postPath($post->slug)) }}</link>
+            {{-- The URL is the identity, and it never changes once published,
+                 which is exactly what a guid has to promise. --}}
+            <guid isPermaLink="true">{{ $page->absolute($page->postPath($post->slug)) }}</guid>
+            <pubDate>{{ $post->rfcDate() }}</pubDate>
+            <dc:creator>{{ $post->author }}</dc:creator>
+            <description>{{ $post->description }}</description>
+            <content:encoded><![CDATA[{!! $post->feedContent() !!}]]></content:encoded>
+        </item>
+@endforeach
+    </channel>
+</rss>

--- a/source/de/blog/feed.blade.xml
+++ b/source/de/blog/feed.blade.xml
@@ -1,0 +1,4 @@
+---
+locale: de
+---
+@include('_partials.blog.feed')

--- a/source/en/blog/feed.blade.xml
+++ b/source/en/blog/feed.blade.xml
@@ -1,0 +1,4 @@
+---
+locale: en
+---
+@include('_partials.blog.feed')

--- a/source/es/blog/feed.blade.xml
+++ b/source/es/blog/feed.blade.xml
@@ -1,0 +1,4 @@
+---
+locale: es
+---
+@include('_partials.blog.feed')

--- a/source/fr/blog/feed.blade.xml
+++ b/source/fr/blog/feed.blade.xml
@@ -1,0 +1,4 @@
+---
+locale: fr
+---
+@include('_partials.blog.feed')


### PR DESCRIPTION
One feed per locale, at `/<locale>/blog/feed.xml`, carrying the 20 newest posts with their full bodies. A reader who subscribes from the French blog gets a feed whose links land back on the French pages, like everything else here.

## Choices worth stating

**RSS 2.0 rather than Atom.** It is what "RSS feed" means to almost everyone, and every reader accepts it. Two namespaces earn their place: `content:encoded` carries the full post body, which `description` is not allowed to do, and `dc:creator` carries an author name, which RSS's own `author` element cannot without an email address attached to it.

**Full bodies rather than summaries.** These posts are short, the screenshots are the point of half of them, and a feed that makes you click through to read two paragraphs is a feed nobody keeps subscribed to. Twenty items keeps the file at 60KB; someone subscribing today gets the last two years and picks up the rest from the site.

**Every URL is made absolute first.** A feed is read on someone else's host, where root-relative markup resolves against that host instead of ours. That is how a feed ends up full of broken screenshots. `feedContent()` rewrites both `src` and `href`, so images and internal links survive the trip. Verified: no root-relative URL survives in any of the four feeds.

**`lastBuildDate` is the newest post's date, not the build's.** A feed that changes its timestamp every time the site is rebuilt teaches readers to ignore it.

**Autodiscovery is on every page, not just the blog.** The page somebody is on when they decide to subscribe is rarely the index. It points at the current locale's feed, which is safe under Turbo for the same reason `<html lang>` is: the link is identical across a locale, and crossing locales is a full page load because the locale picker carries `data-turbo="false"`.

## Checks

`npm run build` passes from a clean tree, dead-link checker included. The autodiscovery `href` is an absolute URL on our own domain, so the checker treats it as internal and confirms it resolves to a real file.

All four feeds parse as XML, carry 20 items each, and were spot-checked end to end: `atom:link rel="self"`, guid matching the permalink, RFC 2822 dates, translated channel metadata, English bodies, and image `src` attributes rewritten to `https://www.monicahq.com/assets/images/blog/…`. Every `]]>` in the output is a CDATA terminator rather than a sequence that would break one.

## Not included

No visible "subscribe" link anywhere. The design has no slot for one, and I would rather not invent UI. Autodiscovery is the mechanism readers actually use, so pasting the blog URL into one finds the feed. Say the word if you want a link in the sidebar or the footer.