### PR TITLE
feat: add the team page

### DIFF
--- a/config.php
+++ b/config.php
@@ -193,6 +193,8 @@ return [
             'es' => 'condiciones-de-uso',
         ],
 
+        'team' => ['en' => 'team', 'fr' => 'equipe', 'de' => 'team', 'es' => 'equipo'],
+
         'privacy' => [
             'en' => 'privacy',
             'fr' => 'confidentialite',

--- a/lang/de.php
+++ b/lang/de.php
@@ -25,6 +25,11 @@ return [
             'description' => "Wie Monica mit Ihren Daten umgeht: was wir erheben, wo es gespeichert wird, wer es sehen kann und was beim Schließen Ihres Kontos passiert. Keine Werbung, keine Tracker, kein Datenverkauf.",
         ],
 
+        'team' => [
+            'title' => "Team — Monica",
+            'description' => "Monica wird von zwei Personen in Montreal gebaut, mit Hunderten von Open-Source-Mitwirkenden. Warum wir ein persönliches CRM bauen, das menschlichen Beziehungen nicht schadet.",
+        ],
+
         'terms' => [
             'title' => "Nutzungsbedingungen — Monica",
             'description' => "Die Nutzungsbedingungen von Monica, dem quelloffenen persönlichen CRM: was der Dienst abdeckt, Ihre Rechte an Ihren Daten, Ihre Pflichten und das rechtliche Kleingedruckte.",
@@ -624,6 +629,7 @@ return [
         'github' => "GitHub",
         'privacy' => "Datenschutz",
         'terms' => "Nutzungsbedingungen",
+        'team' => "Team",
         'copyright' => "© :year Monica",
         'since' => "Quelloffen seit 2017",
         'ownership' => "Ihre Daten bleiben Ihre.",
@@ -775,6 +781,29 @@ return [
                 ],
             ],
         ],
+    ],
+
+    'team' => [
+        'eyebrow' => "Team",
+        'title' => "Monica ist ein Team aus 2 Personen. Mit Hunderten von Mitwirkenden.",
+
+        'stats' => [
+            ['value' => "2016", 'label' => "Erste Zeile Code"],
+            ['value' => "Montreal", 'label' => "Hauptsitz"],
+            ['value' => "2", 'label' => "Offizielle Mitglieder"],
+            ['value' => "Hunderte", 'label' => "Open-Source-Mitwirkende"],
+            ['value' => "Millionen", 'label' => "Verwaltete Kontakte"],
+        ],
+
+        'missionLabel' => "Unsere Mission",
+        'mission' => [
+            "Unsere Mission ist es, Technik so einzusetzen, dass sie menschlichen Beziehungen nicht schadet, wie es große soziale Netzwerke tun können.",
+            "In einer Zeit, in der Menschen Tausende virtueller Freunde haben, wollen wir ein Werkzeug anbieten, das hilft, die Beziehungen zu nur einigen wenigen davon zu stärken. Jede Freundschaft soll wirklich zählen.",
+            "Monica entstand aus einem persönlichen Bedürfnis: mitzubekommen, was Freunde in anderen Ländern gerade in ihrem Leben taten. Nachdem die erste Version des Werkzeugs fertig war, habe ich beschlossen, den Quellcode offenzulegen und das Projekt auf Hacker News vorzustellen. Der Rest ist Geschichte.",
+            "Monica ist heute ein gesundes Open-Source-Projekt. Wir hatten das Glück, eine großartige Community zu bekommen, mit Dutzenden Mitwirkenden und Hunderten Code-Beiträgen. Es wirft auch ein wenig Geld ab: Jeder Dollar, den wir mit diesem Projekt verdienen, fließt zurück in das Projekt, um die Rechnungen zu bezahlen und die Entwicklung voranzubringen.",
+            "Danke, dass Sie sich das Projekt ansehen.",
+        ],
+        'signature' => "Regis Freyd und Alexis Saettler",
     ],
 
     'notFound' => [

--- a/lang/en.php
+++ b/lang/en.php
@@ -35,6 +35,11 @@ return [
             'description' => "How Monica handles your data: what we collect, where it is stored, who can see it, and what happens when you close your account. No ads, no trackers, no data resale.",
         ],
 
+        'team' => [
+            'title' => "Team — Monica",
+            'description' => "Monica is built by two people in Montreal, with hundreds of open-source contributors. Why we build a personal CRM that does not harm human relationships.",
+        ],
+
         'terms' => [
             'title' => "Terms of use — Monica",
             'description' => "The terms of use for Monica, the open-source personal CRM: what the service covers, your rights over your data, your responsibilities, and the legal small print.",
@@ -635,6 +640,7 @@ return [
         'github' => "GitHub",
         'privacy' => "Privacy",
         'terms' => "Terms",
+        'team' => "Team",
         'copyright' => "© :year Monica",
         'since' => "Open source since 2017",
         'ownership' => "Your data stays yours.",
@@ -791,6 +797,40 @@ return [
         ],
     ],
 
+
+    /**
+     * The mission text is the copy published at monicahq.com/team, word for
+     * word, including its grammar. This is the canonical wording; the other
+     * three locales are translations of it.
+     *
+     * The two stat values that were numbers on the old page are words here.
+     * Nothing in this build can count contributors across a repository whose
+     * history was reset, or contacts on a server it never talks to, and a
+     * figure that is wrong a week after it ships is worse than an honest
+     * magnitude.
+     */
+    'team' => [
+        'eyebrow' => "Team",
+        'title' => "Monica is a team of 2. With hundreds of contributors.",
+
+        'stats' => [
+            ['value' => "2016", 'label' => "First line of code"],
+            ['value' => "Montreal", 'label' => "Headquarters"],
+            ['value' => "2", 'label' => "Official members"],
+            ['value' => "Hundreds", 'label' => "Open source contributors"],
+            ['value' => "Millions", 'label' => "Contacts managed"],
+        ],
+
+        'missionLabel' => "Our mission",
+        'mission' => [
+            "Our mission is to use technology in a way that does not harm human relationships, like big social networks can do.",
+            "In an age where people have thousands of virtual friends, we want to provide a tool that helps people strengthen the relationships with only a few of these friends. Make each friendship matter a lot.",
+            "Monica is born out of a personal need to keep track of what friends living in other countries were doing with their lives. After having built the first version of the tool, I decided to open sourced it, promote it on Hacker News and the rest is history.",
+            "Monica is now an healthy open source project. We've been fortunate enough to have a great community, with dozens of contributors and hundreds of code contributions. It also generates a bit of money - every dollar we make on this project is reinvested in the project, to pay the bills and help further development.",
+            "Thanks for checking out the project.",
+        ],
+        'signature' => "Regis Freyd and Alexis Saettler",
+    ],
 
     'notFound' => [
         'title' => "Page not found.",

--- a/lang/es.php
+++ b/lang/es.php
@@ -25,6 +25,11 @@ return [
             'description' => "Cómo trata Monica tus datos: qué recogemos, dónde se almacena, quién puede verlo y qué ocurre cuando cierras tu cuenta. Sin publicidad, sin rastreadores, sin venta de datos.",
         ],
 
+        'team' => [
+            'title' => "Equipo — Monica",
+            'description' => "Monica la construyen dos personas en Montreal, con cientos de personas colaboradoras de código abierto. Por qué hacemos un CRM personal que no daña las relaciones humanas.",
+        ],
+
         'terms' => [
             'title' => "Condiciones de uso — Monica",
             'description' => "Las condiciones de uso de Monica, el CRM personal de código abierto: qué cubre el servicio, tus derechos sobre tus datos, tus responsabilidades y la letra pequeña legal.",
@@ -624,6 +629,7 @@ return [
         'github' => "GitHub",
         'privacy' => "Privacidad",
         'terms' => "Condiciones de uso",
+        'team' => "Equipo",
         'copyright' => "© :year Monica",
         'since' => "De código abierto desde 2017",
         'ownership' => "Tus datos siguen siendo tuyos.",
@@ -775,6 +781,29 @@ return [
                 ],
             ],
         ],
+    ],
+
+    'team' => [
+        'eyebrow' => "Equipo",
+        'title' => "Monica es un equipo de 2. Con cientos de personas colaboradoras.",
+
+        'stats' => [
+            ['value' => "2016", 'label' => "Primera línea de código"],
+            ['value' => "Montreal", 'label' => "Sede"],
+            ['value' => "2", 'label' => "Miembros oficiales"],
+            ['value' => "Cientos", 'label' => "Personas que contribuyen"],
+            ['value' => "Millones", 'label' => "Contactos gestionados"],
+        ],
+
+        'missionLabel' => "Nuestra misión",
+        'mission' => [
+            "Nuestra misión es usar la tecnología de una forma que no dañe las relaciones humanas, como sí pueden hacerlo las grandes redes sociales.",
+            "En una época en la que la gente tiene miles de amigos virtuales, queremos ofrecer una herramienta que ayude a reforzar la relación con solo unos pocos de ellos. Que cada amistad importe de verdad.",
+            "Monica nació de una necesidad personal: seguir la pista de lo que hacían con su vida los amigos que vivían en otros países. Después de construir la primera versión de la herramienta, decidí abrir su código, presentarla en Hacker News y el resto es historia.",
+            "Monica es hoy un proyecto de código abierto con buena salud. Hemos tenido la suerte de contar con una gran comunidad, con decenas de personas colaboradoras y cientos de contribuciones al código. También genera algo de dinero: cada dólar que ganamos con el proyecto se reinvierte en él, para pagar las facturas y seguir desarrollándolo.",
+            "Gracias por interesarte por el proyecto.",
+        ],
+        'signature' => "Regis Freyd y Alexis Saettler",
     ],
 
     'notFound' => [

--- a/lang/fr.php
+++ b/lang/fr.php
@@ -25,6 +25,11 @@ return [
             'description' => "Comment Monica traite vos données : ce que nous collectons, où c'est stocké, qui peut y accéder et ce qui se passe quand vous fermez votre compte. Pas de publicité, pas de traceurs, pas de revente de données.",
         ],
 
+        'team' => [
+            'title' => "Équipe — Monica",
+            'description' => "Monica est construite par deux personnes à Montréal, avec des centaines de contributeurs open source. Pourquoi nous bâtissons un CRM personnel qui ne nuit pas aux relations humaines.",
+        ],
+
         'terms' => [
             'title' => "Conditions d'utilisation — Monica",
             'description' => "Les conditions d'utilisation de Monica, le CRM personnel open source : ce que couvre le service, vos droits sur vos données, vos responsabilités et les mentions légales.",
@@ -624,6 +629,7 @@ return [
         'github' => "GitHub",
         'privacy' => "Confidentialité",
         'terms' => "Conditions d'utilisation",
+        'team' => "Équipe",
         'copyright' => "© :year Monica",
         'since' => "Open source depuis 2017",
         'ownership' => "Vos données restent les vôtres.",
@@ -775,6 +781,29 @@ return [
                 ],
             ],
         ],
+    ],
+
+    'team' => [
+        'eyebrow' => "Équipe",
+        'title' => "Monica, c'est une équipe de 2. Et des centaines de contributeurs.",
+
+        'stats' => [
+            ['value' => "2016", 'label' => "Première ligne de code"],
+            ['value' => "Montréal", 'label' => "Siège social"],
+            ['value' => "2", 'label' => "Membres officiels"],
+            ['value' => "Des centaines", 'label' => "Contributeurs open source"],
+            ['value' => "Des millions", 'label' => "Contacts gérés"],
+        ],
+
+        'missionLabel' => "Notre mission",
+        'mission' => [
+            "Notre mission est d'utiliser la technologie d'une manière qui ne nuit pas aux relations humaines, comme peuvent le faire les grands réseaux sociaux.",
+            "À une époque où les gens ont des milliers d'amis virtuels, nous voulons offrir un outil qui aide à renforcer les liens avec quelques-uns d'entre eux seulement. Que chaque amitié compte vraiment.",
+            "Monica est née d'un besoin personnel : garder le fil de ce que devenaient des amis vivant dans d'autres pays. Après avoir construit la première version de l'outil, j'ai décidé d'en ouvrir le code, de le présenter sur Hacker News, et la suite appartient à l'histoire.",
+            "Monica est aujourd'hui un projet open source en bonne santé. Nous avons la chance d'avoir une belle communauté, avec des dizaines de contributeurs et des centaines de contributions au code. Le projet rapporte aussi un peu d'argent : chaque dollar gagné y est réinvesti, pour payer les factures et faire avancer le développement.",
+            "Merci de vous intéresser au projet.",
+        ],
+        'signature' => "Regis Freyd et Alexis Saettler",
     ],
 
     'notFound' => [

--- a/source/_partials/site-footer.blade.php
+++ b/source/_partials/site-footer.blade.php
@@ -25,6 +25,7 @@
                 // Nothing else on the site links here, and a terms page nobody
                 // can reach is not a terms page.
                 ['label' => $page->t('footer.terms'), 'href' => $page->route('terms')],
+                ['label' => $page->t('footer.team'), 'href' => $page->route('team')],
             ],
         ],
     ];

--- a/source/_partials/team/hero.blade.php
+++ b/source/_partials/team/hero.blade.php
@@ -1,0 +1,15 @@
+{{--
+    The page's opening claim, under a mono eyebrow.
+
+    Capped at 20ch so the headline breaks after "team of 2." on a wide screen,
+    which is where the design puts the turn.
+--}}
+<section>
+    <div class="mx-auto w-full max-w-marketing px-4 pt-16 pb-10 md:px-8">
+        <span class="font-mono text-mono text-text-muted">{{ $page->t('team.eyebrow') }}</span>
+
+        <h1 class="mt-4 max-w-[20ch] text-display-sm font-semibold text-pretty md:text-display-lg lg:text-display-xl">
+            {{ $page->t('team.title') }}
+        </h1>
+    </div>
+</section>

--- a/source/_partials/team/mission.blade.php
+++ b/source/_partials/team/mission.blade.php
@@ -1,0 +1,27 @@
+{{--
+    The mission statement, with the label in its own column beside it.
+
+    The label column is a fixed 180px on wide screens and stacks above the text
+    below `lg`, which is what keeps the prose measure from collapsing on a
+    tablet. The signature is set apart by a hairline rather than by a heading:
+    it is an attribution, not a section.
+--}}
+<section class="border-t border-border">
+    <div class="mx-auto w-full max-w-marketing px-4 py-section-sm md:px-8 lg:py-section">
+        <div class="grid gap-6 lg:grid-cols-[180px_minmax(0,1fr)] lg:gap-10">
+            <div class="font-mono text-mono text-text-muted">{{ $page->t('team.missionLabel') }}</div>
+
+            <div class="max-w-[66ch]">
+                @foreach ($page->t('team.mission') as $paragraph)
+                    <p class="text-copy-lg leading-[1.65] text-text-secondary text-pretty {{ ! $loop->first ? 'mt-5' : '' }}">
+                        {{ $paragraph }}
+                    </p>
+                @endforeach
+
+                <p class="mt-8 border-t border-border-subtle pt-5 text-copy-lg font-medium text-text">
+                    {{ $page->t('team.signature') }}
+                </p>
+            </div>
+        </div>
+    </div>
+</section>

--- a/source/_partials/team/stats.blade.php
+++ b/source/_partials/team/stats.blade.php
@@ -1,0 +1,31 @@
+{{--
+    Five facts about the project, in one bordered row.
+
+    The borders are drawn by the cells rather than the container, so the grid
+    keeps working when it reflows. Every cell carries a left and a top border
+    and then removes the ones that would sit on an outside edge: on the wide
+    grid that is the first cell's left border and every top border, and on the
+    two-column one it is the left border of each odd cell and the top border of
+    the first row. `overflow-hidden` on the container is what keeps the cells
+    from squaring off its rounded corners.
+
+    Two of these are words rather than numbers. "Hundreds" and "Millions" are
+    the honest shape of a figure that nothing here can count and that would be
+    wrong a week after it shipped.
+--}}
+@php
+    $cell = 'border-t border-l border-border px-5 py-6 max-lg:odd:border-l-0 max-lg:[&:nth-child(-n+2)]:border-t-0 lg:border-t-0 lg:first:border-l-0';
+@endphp
+
+<section>
+    <div class="mx-auto w-full max-w-marketing px-4 pb-16 md:px-8">
+        <div class="grid grid-cols-2 overflow-hidden rounded-lg border border-border lg:grid-cols-5">
+            @foreach ($page->t('team.stats') as $stat)
+                <div class="{{ $cell }}">
+                    <div class="text-heading font-semibold">{{ $stat['value'] }}</div>
+                    <div class="mt-2 text-small text-text-secondary">{{ $stat['label'] }}</div>
+                </div>
+            @endforeach
+        </div>
+    </div>
+</section>

--- a/source/de/team.blade.php
+++ b/source/de/team.blade.php
@@ -1,0 +1,11 @@
+---
+locale: de
+page: team
+---
+@extends('_layouts.base')
+
+@section('body')
+    @include('_partials.team.hero')
+    @include('_partials.team.stats')
+    @include('_partials.team.mission')
+@endsection

--- a/source/en/team.blade.php
+++ b/source/en/team.blade.php
@@ -1,0 +1,11 @@
+---
+locale: en
+page: team
+---
+@extends('_layouts.base')
+
+@section('body')
+    @include('_partials.team.hero')
+    @include('_partials.team.stats')
+    @include('_partials.team.mission')
+@endsection

--- a/source/es/equipo.blade.php
+++ b/source/es/equipo.blade.php
@@ -1,0 +1,11 @@
+---
+locale: es
+page: team
+---
+@extends('_layouts.base')
+
+@section('body')
+    @include('_partials.team.hero')
+    @include('_partials.team.stats')
+    @include('_partials.team.mission')
+@endsection

--- a/source/fr/equipe.blade.php
+++ b/source/fr/equipe.blade.php
@@ -1,0 +1,11 @@
+---
+locale: fr
+page: team
+---
+@extends('_layouts.base')
+
+@section('body')
+    @include('_partials.team.hero')
+    @include('_partials.team.stats')
+    @include('_partials.team.mission')
+@endsection


### PR DESCRIPTION
Closes #14.

The Team page from `Team.dc.html`, at a translated slug per locale:

| en | fr | de | es |
| :--- | :--- | :--- | :--- |
| `/en/team/` | `/fr/equipe/` | `/de/team/` | `/es/equipo/` |

The footer's Project column gains a link, which is where the issue asked for it. The design also puts Team in the main nav; I left the nav alone, so Documentation keeps its slot. Happy to make that swap if you want the nav to match the design too.

## The copy is the published one

The mission text turned out to be live at monicahq.com/team already, so I copied it word for word rather than rewriting it, the same as with the terms and the privacy policy. English is canonical; French, German and Spanish are translations of it.

That does mean three small grammar slips ship as-is, because they are yours and rewriting marketing copy is not my call:

- "Monica **is** born out of a personal need" (was born)
- "I decided to **open sourced** it" (to open source it)
- "Monica is now **an healthy** open source project" (a healthy)

Say the word and I will fix all three in the English and leave the translations, which already read correctly.

## Two statistics are words now

The published page claims **150** open source contributors and **210,403** contacts managed. Per your call, those read **"Hundreds"** and **"Millions"**.

Worth recording why that is the better answer and not just a softer one: the GitHub API reports 40 contributors on `monicahq/monica`, because the repository's history was reset in December 2021 for the Chandler rewrite, so the real figure is unknowable from here and 40 would be badly wrong. The contacts number is on a server this build never talks to, and it was stale the day it was written. It also settles an inconsistency the old page had, where the headline said "hundreds of contributors" directly above a tile claiming 150.

The other three (2016, Montreal, 2 members) are unchanged and consistent with what the site and the blog already say.

## The stats row

The borders are drawn by the cells rather than the container, so the row survives its reflow from five columns to two. Each cell carries a left and a top border and then removes the ones that would land on an outside edge: on the wide grid that is the first cell's left border and every top border, on the narrow one it is the left border of each odd cell and the top border of the first row.

That is the one piece here worth a second look in review, so I checked the compiled stylesheet rather than assuming: the `:nth-child(-n+2)`, `:nth-child(odd)` and `:first-child` rules and the 5-column grid are all present.

## Checks

`npm run build` passes clean, dead-link checker included. All four pages are in the sitemap, each canonical is self-referential, and the hreflang clusters cross-link translated slugs correctly (the German page's French alternate is `/fr/equipe/`, not `/fr/team/`). Verified the five stat tiles render their values and labels, and the five mission paragraphs plus the signature appear in every locale.