### PR TITLE
refactor: stop promising an MIT licence in v3

### DIFF
--- a/lang/de.php
+++ b/lang/de.php
@@ -52,13 +52,13 @@ return [
 
         'v3' => [
             'title' => "Monica v3 — neu gebaut für die nächsten zehn Jahre",
-            'description' => "Monica v3 ist ein vollständiger Neubau des quelloffenen persönlichen CRM: Einträge, die Sie selbst gestalten, ein mit allem verbundenes Journal, eine vollständige API und eine echte mobile Erfahrung. Weiterhin quelloffen, jetzt unter MIT-Lizenz. Vor Ende 2026.",
+            'description' => "Monica v3 ist ein vollständiger Neubau des quelloffenen persönlichen CRM: Einträge, die Sie selbst gestalten, ein mit allem verbundenes Journal, eine vollständige API und eine echte mobile Erfahrung. Weiterhin quelloffen. Vor Ende 2026.",
         ],
     ],
 
     'announcement' => [
         'headline' => "Monica v3 kommt vor Ende 2026.",
-        'detail' => "Von Grund auf neu gebaut. Weiterhin quelloffen. Jetzt unter MIT-Lizenz.",
+        'detail' => "Von Grund auf neu gebaut. Weiterhin quelloffen.",
         'cta' => "Sehen, was kommt",
     ],
 
@@ -81,7 +81,7 @@ return [
         'lede2' => "Privat von Grund auf. Quelloffen. Selbst hostbar. Keine Werbung, kein Datenverkauf, keine peinlichen Benachrichtigungen zur „Aktivierung“.",
         'primaryCta' => "Mit Monica beginnen",
         'githubCta' => "Auf GitHub ansehen · :count Sterne",
-        'note' => "Selbst hosten ist kostenlos · Gehostete Version verfügbar · MIT-lizenziert ab v3",
+        'note' => "Selbst hosten ist kostenlos · Gehostete Version verfügbar",
     ],
 
     'proof' => [
@@ -188,7 +188,6 @@ return [
         'listTitle' => "Mit Monica v3:",
         'items' => [
             "bleibt das Projekt vollständig quelloffen;",
-            "wird die Lizenz zu MIT;",
             "können Sie es auf Ihrem eigenen Server betreiben;",
             "nutzt das gehostete Produkt dieselbe Anwendung;",
             "lassen sich Ihre Daten exportieren;",
@@ -243,7 +242,7 @@ return [
         'timing' => "Kommt vor Ende 2026",
         'title' => "Monica wird für die nächsten zehn Jahre neu gebaut.",
         'lede' => "Monica hat Tausenden Menschen geholfen, sich an das zu erinnern, was bei den Menschen in ihrem Leben zählt. Jetzt wird sie von Grund auf neu gebaut: flexibler, privater, leichter erweiterbar und besser auf jedem Bildschirm.",
-        'lede2' => "Sie bleibt quelloffen. Sie wechselt zur MIT-Lizenz. Und alles, was Monica von Anfang an lohnend gemacht hat, bleibt erhalten.",
+        'lede2' => "Sie bleibt quelloffen. Und alles, was Monica von Anfang an lohnend gemacht hat, bleibt erhalten.",
 
         'form' => [
             'label' => "E-Mail-Adresse",
@@ -303,8 +302,8 @@ return [
             'items' => [
                 [
                     'icon' => 'code',
-                    'title' => "Quelloffen, jetzt unter MIT",
-                    'body' => "Monica bleibt vollständig quelloffen und selbst hostbar. Version 3 verwendet die MIT-Lizenz und ist damit einfacher zu verstehen, wiederzuverwenden, zu erweitern und zu ergänzen.",
+                    'title' => "Quelloffen, und das bleibt so",
+                    'body' => "Monica bleibt vollständig quelloffen und selbst hostbar. Der Code lässt sich weiterhin lesen, verändern, forken und ergänzen, genau wie heute.",
                 ],
                 [
                     'icon' => 'lock',
@@ -332,7 +331,7 @@ return [
         'follow' => [
             'title' => "Verfolgen Sie den Neubau von Anfang an.",
             'body' => "Monica v3 ist noch in Entwicklung, und viele wichtige Entscheidungen fallen öffentlich. Tragen Sie sich in die Startliste ein oder folgen Sie dem Repository, um die Arbeit mitzuverfolgen.",
-            'note' => "Quelloffen · MIT-Lizenz · Öffentlich entwickelt",
+            'note' => "Quelloffen · Selbst hostbar · Öffentlich entwickelt",
             'primaryCta' => "Start-E-Mail erhalten",
             'secondaryCta' => "Monica auf GitHub folgen",
         ],
@@ -483,8 +482,7 @@ return [
                 "Datenimport und -export;",
                 "Dokumentation der Community;",
                 "Unterstützung durch die Community;",
-                "die Möglichkeit, den Quellcode einzusehen und zu ändern;",
-                "die MIT-Lizenz in Monica v3.",
+                "die Möglichkeit, den Quellcode einzusehen und zu ändern.",
             ],
             'footnote' => "Die selbst gehostete Ausgabe ist keine abgespeckte Demo. Es ist Monica auf Ihrer Infrastruktur.",
             'footnote2' => "Verwaltete Sicherungen, E-Mail-Versand, Infrastrukturüberwachung und direkter Support gehören zum gehosteten Dienst.",
@@ -565,7 +563,7 @@ return [
                 ['q' => "Gilt der Preis pro Nutzer oder pro Kontakt?", 'a' => "Nein. Der gehostete Tarif hat einen Preis pro Konto und enthält unbegrenzte Kontakte."],
                 ['q' => "Ist Monica wirklich quelloffen?", 'a' => [
                     "Ja. Der Quellcode von Monica ist öffentlich, und das Projekt hat :count Sterne auf GitHub.",
-                    "Monica v3 wird unter der MIT-Lizenz veröffentlicht.",
+                    "Monica v3 bleibt quelloffen und selbst hostbar.",
                 ], 'link' => ['label' => "Mehr über Monica v3 lesen", 'page' => 'v3']],
                 ['q' => "Ist Selbst-Hosten kostenlos?", 'a' => "Monica berechnet nichts für die selbst gehostete Software. Server und Infrastrukturkosten tragen Sie."],
                 ['q' => "Unterscheidet sich die gehostete von der selbst gehosteten Version?", 'a' => [

--- a/lang/en.php
+++ b/lang/en.php
@@ -62,13 +62,13 @@ return [
 
         'v3' => [
             'title' => "Monica v3 — rebuilt for the next ten years",
-            'description' => "Monica v3 is a ground-up rebuild of the open-source personal CRM: records you design, a journal connected to everything, a complete API, and a proper mobile experience. Still open source, now MIT licensed. Coming before the end of 2026.",
+            'description' => "Monica v3 is a ground-up rebuild of the open-source personal CRM: records you design, a journal connected to everything, a complete API, and a proper mobile experience. Still open source. Coming before the end of 2026.",
         ],
     ],
 
     'announcement' => [
         'headline' => "Monica v3 is coming before the end of 2026.",
-        'detail' => "Rebuilt from scratch. Still open source. Now MIT licensed.",
+        'detail' => "Rebuilt from scratch. Still open source.",
         'cta' => "See what is coming",
     ],
 
@@ -91,7 +91,7 @@ return [
         'lede2' => "Private by design. Open source. Self-hostable. No ads, no data resale, no awkward “engagement” notifications.",
         'primaryCta' => "Start using Monica",
         'githubCta' => "View on GitHub · :count stars",
-        'note' => "Free to self-host · Hosted version available · MIT licensed in v3",
+        'note' => "Free to self-host · Hosted version available",
     ],
 
     'proof' => [
@@ -199,7 +199,6 @@ return [
         'listTitle' => "With Monica v3:",
         'items' => [
             "the project remains fully open source;",
-            "the license becomes MIT;",
             "you can run it on your own server;",
             "the hosted product uses the same core application;",
             "your data can be exported;",
@@ -254,7 +253,7 @@ return [
         'timing' => "Coming before the end of 2026",
         'title' => "Monica is being rebuilt for the next ten years.",
         'lede' => "Monica has helped thousands of people remember what matters about the people in their lives. Now it is being rebuilt from the ground up: more flexible, more private, easier to extend, and better on every screen.",
-        'lede2' => "It will remain open source. It will become MIT licensed. And everything that made Monica worth using in the first place is staying.",
+        'lede2' => "It will remain open source. And everything that made Monica worth using in the first place is staying.",
 
         'form' => [
             'label' => "Email address",
@@ -314,8 +313,8 @@ return [
             'items' => [
                 [
                     'icon' => 'code',
-                    'title' => "Open source, now under MIT",
-                    'body' => "Monica will remain fully open source and self-hostable. Version 3 will use the MIT license, making it simpler to understand, reuse, extend, and contribute to.",
+                    'title' => "Open source, and staying open source",
+                    'body' => "Monica will remain fully open source and self-hostable. The code can be read, modified, forked, and contributed to, exactly as it can today.",
                 ],
                 [
                     'icon' => 'lock',
@@ -343,7 +342,7 @@ return [
         'follow' => [
             'title' => "Follow the rebuild from the beginning.",
             'body' => "Monica v3 is still in development, and many important decisions are being made in the open. Join the launch list or follow the repository to see the work as it happens.",
-            'note' => "Open source · MIT licensed · Built in public",
+            'note' => "Open source · Self-hostable · Built in public",
             'primaryCta' => "Get the launch email",
             'secondaryCta' => "Follow Monica on GitHub",
         ],
@@ -494,8 +493,7 @@ return [
                 "data import and export;",
                 "community documentation;",
                 "community support;",
-                "the ability to inspect and modify the source code;",
-                "the MIT license in Monica v3.",
+                "the ability to inspect and modify the source code.",
             ],
             'footnote' => "The self-hosted edition is not a stripped-down demo. It is Monica running on your infrastructure.",
             'footnote2' => "Managed backups, hosted email delivery, infrastructure monitoring, and direct support are part of the hosted service.",
@@ -576,7 +574,7 @@ return [
                 ['q' => "Is the price per user or per contact?", 'a' => "No. The hosted plan has one account price and includes unlimited contacts."],
                 ['q' => "Is Monica really open source?", 'a' => [
                     "Yes. Monica's source code is publicly available, and the project has :count stars on GitHub.",
-                    "Monica v3 will be released under the MIT license.",
+                    "Monica v3 will stay open source and self-hostable.",
                 ], 'link' => ['label' => "Read about Monica v3", 'page' => 'v3']],
                 ['q' => "Is self-hosting free?", 'a' => "Monica does not charge for the self-hosted software. You are responsible for the server and any infrastructure costs."],
                 ['q' => "Is the hosted version different from the self-hosted version?", 'a' => [

--- a/lang/es.php
+++ b/lang/es.php
@@ -52,13 +52,13 @@ return [
 
         'v3' => [
             'title' => "Monica v3 — reconstruida para los próximos diez años",
-            'description' => "Monica v3 es una reconstrucción completa del CRM personal de código abierto: fichas que diseñas tú, un diario conectado con todo lo demás, una API completa y una experiencia móvil de verdad. Sigue siendo de código abierto, ahora con licencia MIT. Antes de que acabe 2026.",
+            'description' => "Monica v3 es una reconstrucción completa del CRM personal de código abierto: fichas que diseñas tú, un diario conectado con todo lo demás, una API completa y una experiencia móvil de verdad. Sigue siendo de código abierto. Antes de que acabe 2026.",
         ],
     ],
 
     'announcement' => [
         'headline' => "Monica v3 llega antes de que acabe 2026.",
-        'detail' => "Reconstruida desde cero. Sigue siendo de código abierto. Ahora con licencia MIT.",
+        'detail' => "Reconstruida desde cero. Sigue siendo de código abierto.",
         'cta' => "Ver lo que viene",
     ],
 
@@ -81,7 +81,7 @@ return [
         'lede2' => "Privada por diseño. De código abierto. Alojable por ti. Sin anuncios, sin reventa de datos, sin notificaciones incómodas para «reengancharte».",
         'primaryCta' => "Empezar con Monica",
         'githubCta' => "Ver en GitHub · :count estrellas",
-        'note' => "Alojarla tú es gratis · Versión alojada disponible · Con licencia MIT en la v3",
+        'note' => "Alojarla tú es gratis · Versión alojada disponible",
     ],
 
     'proof' => [
@@ -188,7 +188,6 @@ return [
         'listTitle' => "Con Monica v3:",
         'items' => [
             "el proyecto sigue siendo totalmente de código abierto;",
-            "la licencia pasa a ser MIT;",
             "puedes ejecutarla en tu propio servidor;",
             "el producto alojado usa la misma aplicación;",
             "tus datos se pueden exportar;",
@@ -243,7 +242,7 @@ return [
         'timing' => "Antes de que acabe 2026",
         'title' => "Monica se está reconstruyendo para los próximos diez años.",
         'lede' => "Monica ha ayudado a miles de personas a recordar lo que importa de quienes las rodean. Ahora se está reconstruyendo desde cero: más flexible, más privada, más fácil de ampliar y mejor en cualquier pantalla.",
-        'lede2' => "Seguirá siendo de código abierto. Pasará a licencia MIT. Y todo lo que hacía que Monica mereciera la pena se queda.",
+        'lede2' => "Seguirá siendo de código abierto. Y todo lo que hacía que Monica mereciera la pena se queda.",
 
         'form' => [
             'label' => "Correo electrónico",
@@ -303,8 +302,8 @@ return [
             'items' => [
                 [
                     'icon' => 'code',
-                    'title' => "De código abierto, ahora con MIT",
-                    'body' => "Monica seguirá siendo totalmente de código abierto y alojable por ti. La versión 3 usará la licencia MIT, más sencilla de entender, reutilizar, ampliar y a la que contribuir.",
+                    'title' => "De código abierto, y seguirá siéndolo",
+                    'body' => "Monica seguirá siendo totalmente de código abierto y alojable por ti. El código se podrá leer, modificar, bifurcar y mejorar, igual que hoy.",
                 ],
                 [
                     'icon' => 'lock',
@@ -332,7 +331,7 @@ return [
         'follow' => [
             'title' => "Sigue la reconstrucción desde el principio.",
             'body' => "Monica v3 aún está en desarrollo y muchas decisiones importantes se toman en abierto. Apúntate a la lista de lanzamiento o sigue el repositorio para ver el trabajo según avanza.",
-            'note' => "Código abierto · Licencia MIT · Desarrollada en público",
+            'note' => "Código abierto · Alojable por ti · Desarrollada en público",
             'primaryCta' => "Recibir el correo de lanzamiento",
             'secondaryCta' => "Seguir a Monica en GitHub",
         ],
@@ -483,8 +482,7 @@ return [
                 "importación y exportación de datos;",
                 "documentación de la comunidad;",
                 "soporte de la comunidad;",
-                "la posibilidad de inspeccionar y modificar el código;",
-                "la licencia MIT en Monica v3.",
+                "la posibilidad de inspeccionar y modificar el código.",
             ],
             'footnote' => "La edición autoalojada no es una demo recortada. Es Monica funcionando en tu infraestructura.",
             'footnote2' => "Las copias de seguridad gestionadas, el envío de correo, la supervisión de la infraestructura y el soporte directo forman parte del servicio alojado.",
@@ -565,7 +563,7 @@ return [
                 ['q' => "¿El precio es por usuario o por contacto?", 'a' => "No. El plan alojado tiene un único precio por cuenta e incluye contactos ilimitados."],
                 ['q' => "¿Monica es realmente de código abierto?", 'a' => [
                     "Sí. El código de Monica es público y el proyecto tiene :count estrellas en GitHub.",
-                    "Monica v3 se publicará con licencia MIT.",
+                    "Monica v3 seguirá siendo de código abierto y alojable por ti.",
                 ], 'link' => ['label' => "Leer sobre Monica v3", 'page' => 'v3']],
                 ['q' => "¿Autoalojar es gratis?", 'a' => "Monica no cobra por el software autoalojado. El servidor y los costes de infraestructura corren de tu cuenta."],
                 ['q' => "¿La versión alojada es distinta de la autoalojada?", 'a' => [

--- a/lang/fr.php
+++ b/lang/fr.php
@@ -52,13 +52,13 @@ return [
 
         'v3' => [
             'title' => "Monica v3 — reconstruite pour les dix prochaines années",
-            'description' => "Monica v3 est une reconstruction complète du CRM personnel open source : des fiches que vous concevez, un journal relié à tout le reste, une API complète et une vraie expérience mobile. Toujours open source, désormais sous licence MIT. Avant la fin de 2026.",
+            'description' => "Monica v3 est une reconstruction complète du CRM personnel open source : des fiches que vous concevez, un journal relié à tout le reste, une API complète et une vraie expérience mobile. Toujours open source. Avant la fin de 2026.",
         ],
     ],
 
     'announcement' => [
         'headline' => "Monica v3 arrive avant la fin de 2026.",
-        'detail' => "Reconstruite de zéro. Toujours open source. Désormais sous licence MIT.",
+        'detail' => "Reconstruite de zéro. Toujours open source.",
         'cta' => "Découvrir ce qui arrive",
     ],
 
@@ -81,7 +81,7 @@ return [
         'lede2' => "Privée par conception. Open source. Auto-hébergeable. Aucune publicité, aucune revente de données, aucune notification gênante pour vous « réengager ».",
         'primaryCta' => "Commencer avec Monica",
         'githubCta' => "Voir sur GitHub · :count étoiles",
-        'note' => "Auto-hébergement gratuit · Version hébergée disponible · Sous licence MIT en v3",
+        'note' => "Auto-hébergement gratuit · Version hébergée disponible",
     ],
 
     'proof' => [
@@ -188,7 +188,6 @@ return [
         'listTitle' => "Avec Monica v3 :",
         'items' => [
             "le projet reste entièrement open source ;",
-            "la licence devient MIT ;",
             "vous pouvez l’exécuter sur votre propre serveur ;",
             "la version hébergée utilise la même application ;",
             "vos données peuvent être exportées ;",
@@ -243,7 +242,7 @@ return [
         'timing' => "Avant la fin de 2026",
         'title' => "Monica est reconstruite pour les dix prochaines années.",
         'lede' => "Monica a aidé des milliers de personnes à se souvenir de ce qui compte chez celles et ceux qui les entourent. Elle est aujourd'hui reconstruite de fond en comble : plus souple, plus privée, plus facile à étendre, et meilleure sur tous les écrans.",
-        'lede2' => "Elle restera open source. Elle passera sous licence MIT. Et tout ce qui faisait l'intérêt de Monica reste en place.",
+        'lede2' => "Elle restera open source. Et tout ce qui faisait l'intérêt de Monica reste en place.",
 
         'form' => [
             'label' => "Adresse e-mail",
@@ -303,8 +302,8 @@ return [
             'items' => [
                 [
                     'icon' => 'code',
-                    'title' => "Open source, désormais sous MIT",
-                    'body' => "Monica restera entièrement open source et auto-hébergeable. La version 3 adoptera la licence MIT, plus simple à comprendre, à réutiliser, à étendre et à laquelle contribuer.",
+                    'title' => "Open source, et elle le restera",
+                    'body' => "Monica restera entièrement open source et auto-hébergeable. Le code pourra être lu, modifié, forké et enrichi, exactement comme aujourd'hui.",
                 ],
                 [
                     'icon' => 'lock',
@@ -332,7 +331,7 @@ return [
         'follow' => [
             'title' => "Suivez la reconstruction depuis le début.",
             'body' => "Monica v3 est encore en développement, et beaucoup de décisions importantes se prennent au grand jour. Inscrivez-vous à la liste de lancement ou suivez le dépôt pour voir le travail avancer.",
-            'note' => "Open source · Licence MIT · Développée en public",
+            'note' => "Open source · Auto-hébergeable · Développée en public",
             'primaryCta' => "Recevoir l'e-mail de lancement",
             'secondaryCta' => "Suivre Monica sur GitHub",
         ],
@@ -483,8 +482,7 @@ return [
                 "l'import et l'export des données ;",
                 "la documentation communautaire ;",
                 "le support communautaire ;",
-                "la possibilité d'inspecter et de modifier le code source ;",
-                "la licence MIT dans Monica v3.",
+                "la possibilité d'inspecter et de modifier le code source.",
             ],
             'footnote' => "L'édition auto-hébergée n'est pas une démo bridée. C'est Monica, sur votre infrastructure.",
             'footnote2' => "Les sauvegardes gérées, l'envoi d'e-mails, la supervision de l'infrastructure et le support direct font partie du service hébergé.",
@@ -565,7 +563,7 @@ return [
                 ['q' => "Le prix est-il par utilisateur ou par contact ?", 'a' => "Non. L'offre hébergée a un seul prix par compte et inclut des contacts illimités."],
                 ['q' => "Monica est-elle vraiment open source ?", 'a' => [
                     "Oui. Le code source de Monica est public, et le projet compte :count étoiles sur GitHub.",
-                    "Monica v3 sera publiée sous licence MIT.",
+                    "Monica v3 restera open source et auto-hébergeable.",
                 ], 'link' => ['label' => "En savoir plus sur Monica v3", 'page' => 'v3']],
                 ['q' => "L'auto-hébergement est-il gratuit ?", 'a' => "Monica ne facture pas le logiciel auto-hébergé. Le serveur et les frais d'infrastructure sont à votre charge."],
                 ['q' => "La version hébergée diffère-t-elle de la version auto-hébergée ?", 'a' => [


### PR DESCRIPTION
## What

Monica v3 will not be MIT licensed after all, so the site should stop saying it will. This removes every mention of MIT across the four locale files.

## Why

The promise appeared in ten places per language: the v3 SEO description, the announcement bar, the hero note, the homepage open-source list, the v3 page lede, one of its principle cards, the follow-the-rebuild note, the pricing page self-hosted list, and the pricing FAQ.

## How

v3 stays open source and self-hostable, so only the licence claim is dropped. The surrounding copy keeps the open-source promises without naming a future licence.

- Sentences that carried MIT as a second clause lose that clause ("Rebuilt from scratch. Still open source.").
- Two list items existed only to announce the licence and are gone; the item before each now takes the closing full stop.
- The v3 principle card "Open source, now under MIT" becomes "Open source, and staying open source", with a body about reading, modifying and forking the code rather than about the licence.
- The hero note drops to two segments, since the third one was the licence.
- The pricing FAQ answer to "Is Monica really open source?" now says v3 stays open source and self-hostable.

Translations updated in French, Spanish and German alongside English.

## Testing

`npm run build` passes, including the dead-link check. No MIT string remains in the built HTML or the sitemap.