### PR TITLE
ci: deploy to Cloudflare Pages on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,11 @@
 # real domain, and the one where the link check is strict rather than advisory.
 name: CI
 
+# Pull requests only. A push to main runs the same build inside
+# `deploy.yml`, where a failure also stops the deploy, so running it here as
+# well would build main twice and prove nothing the deploy has not.
 on:
   pull_request:
-  push:
-    branches: [main]
 
 # A second push to the same branch makes the first run irrelevant.
 concurrency:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,77 @@
+# Builds the site and publishes it to Cloudflare Pages, on every push to main.
+#
+# The build is the same one CI runs on a pull request, for the same reason: it
+# is the only thing that catches a missing translation key or a dead link, and
+# `npm run build` resolves to `vite build`, which spawns the Jigsaw production
+# build behind it. A failure here is a failed deploy, so main never ships a
+# broken page.
+#
+# Cloudflare builds nothing. It receives the finished `build_production/`
+# directory, because a Pages build image has no PHP and therefore no Jigsaw.
+name: Deploy to Cloudflare Pages
+
+on:
+  push:
+    branches: [main]
+  # A deploy that failed on a flaky network call should be repeatable without
+  # an empty commit.
+  workflow_dispatch:
+
+# One production deploy at a time. Not cancel-in-progress: a half-finished
+# upload is worse than a superseded one, and the next push deploys over it
+# anyway.
+concurrency:
+  group: cloudflare-pages-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build and deploy
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      # Lets wrangler record the deployment against the commit, which is what
+      # puts the live URL on the commit in GitHub's UI.
+      deployments: write
+
+    steps:
+      - uses: actions/checkout@v7
+
+      # The runner's own PHP is 8.3, and composer.lock resolves to Symfony 8,
+      # which needs 8.4.1. composer.json says so; this is where it is honoured.
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: none
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install PHP dependencies
+        run: composer install --no-dev --no-interaction --prefer-dist --no-progress
+
+      - name: Install node dependencies
+        run: npm ci
+
+      - name: Build the site
+        # Only lifts the GitHub API rate limit for the star count, which is
+        # shared across everything else running on this runner's IP. The build
+        # falls back to the figure in config.php if the call fails, so a rate
+        # limit shows a stale number rather than failing the deploy.
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: npm run build
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+          # `--branch` is explicit because wrangler otherwise infers it from the
+          # checkout, and anything other than the project's production branch
+          # publishes a preview instead of the live site.
+          command: pages deploy build_production --project-name=marketing --branch=main


### PR DESCRIPTION
Adds `.github/workflows/deploy.yml`. Every push to `main` builds the site on the runner and uploads the finished `build_production/` directory to the Cloudflare Pages project `marketing`.

Cloudflare builds nothing. Its build image has no PHP, so it has no Jigsaw. The runner does the work and Pages only hosts the result.

The build step is the same one CI runs on a pull request, which matters because this repository puts its invariants in the build: a missing translation key throws, and so does a dead link. A failure here is a failed deploy, so `main` never ships a broken page.

Changes from the draft that was handed over:

- Action versions moved to the current majors (`checkout@v7`, `setup-node@v7`, `wrangler-action@v4`).
- `GITHUB_TOKEN` passed to the build, so the star count fetch is not stuck behind the 60 per hour unauthenticated limit shared across the runner's IP.
- `cancel-in-progress: false`. A half-finished upload is worse than a superseded one, and the next push deploys over it anyway.
- `--branch=main` is explicit. Wrangler otherwise infers the branch from the checkout, and anything other than the project's production branch publishes a preview rather than the live site.
- `workflow_dispatch` added, so a deploy that failed on a flaky network call can be repeated without an empty commit.
- `ci.yml` no longer runs on pushes to `main`. The deploy runs the identical build, so keeping both meant building `main` twice and proving nothing the deploy does not.

## Before this can merge

Two repository secrets are needed, neither of which exists yet:

- `CLOUDFLARE_API_TOKEN`, scoped to `Account > Cloudflare Pages > Edit`.
- `CLOUDFLARE_ACCOUNT_ID`.

The Pages project `marketing` also has to exist with `main` as its production branch, and its Git integration should be disconnected if it was ever connected, otherwise Cloudflare will try to build the site itself and fail on the missing PHP.