### PR TITLE
fix(assets): point Vite's base at /assets/build so the webfont resolves

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,7 +4,15 @@ import tailwindcss from '@tailwindcss/vite';
 
 // Two entry points: the stylesheet, and the site's single script (Alpine, for
 // the pricing page's billing toggle). Templates resolve both through `vite()`.
-export default defineConfig({
+export default defineConfig(({ command }) => ({
+    // Assets referenced from inside a bundled file (the webfont, from the
+    // @font-face in design-system/fonts.css) are rewritten by Vite as
+    // `base` + their path in the manifest. Jigsaw's `vite()` helper serves
+    // the build from /assets/build, so `base` has to say the same thing or
+    // the font 404s in production while the stylesheet that asks for it
+    // loads fine. Only on `build`: the dev server is addressed by origin
+    // alone, so a base there would break every module URL.
+    base: command === 'build' ? '/assets/build/' : '/',
     plugins: [
         jigsaw({
             input: ['source/_assets/css/main.css', 'source/_assets/js/app.js'],
@@ -12,4 +20,4 @@ export default defineConfig({
         }),
         tailwindcss(),
     ],
-});
+}));


### PR DESCRIPTION
## What

Inter was 404ing in production: `GET /build/assets/Inter-Variable-BiZvS1hC.woff2` returned Cloudflare's 404 page, so every page fell back to a system sans.

## Why

Two different things build the URL of a built asset, and they disagreed.

The `<link>` and `<script>` tags go through Jigsaw's `vite()` helper, which reads the manifest and prefixes `/assets/build`. Those were always correct.

The webfont is not referenced from a template. It is referenced from inside a bundled file, the `@font-face` in `design-system/fonts.css`, so Vite is the one that rewrites it, as `base` + the manifest path. `base` resolved to `/build/` on a production build, which is not where Jigsaw writes the bundle. The stylesheet that asked for the font loaded fine from `/assets/build/`, which is what made this look like a font problem rather than a path one.

## The fix

Set `base` to `/assets/build/` on `build`, matching the helper. Left at `/` on `serve`, because the dev server is addressed by origin alone (`vite()` returns `{origin}/{asset}` from the hot file), so a base there would break every module URL. That was already the resolved value in dev, so nothing changes for `npm run dev`.

## Verified

Clean `npm run build`, then served `build_production/` and requested the two:

- `/assets/build/assets/Inter-Variable-BiZvS1hC.woff2` -> `200 font/woff2`, 48,556 bytes
- `/assets/build/assets/main-D57ggE7w.css` -> `200`, and its `url()` now reads `/assets/build/assets/Inter-Variable-BiZvS1hC.woff2`

The markup still points at `/assets/build/assets/main-*.css` and `/assets/build/assets/app-*.js`, unchanged.