### PR TITLE
feat(sitemap): give every URL a real lastmod

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -82,6 +82,7 @@ Three helpers, and the distinction matters:
 1. Add its key and one slug per locale to `routes` in `config.php`.
 2. Create one Blade file per locale, named after that locale's slug.
 3. Add its copy to every `lang/` file.
+4. Add its key to the `lastmod` map in `config.php`. The sitemap throws without it.
 
 ### Adding a locale
 
@@ -163,6 +164,7 @@ Partials take data through the `@include` array: `@include('_partials.icon', ['n
 - hreflang is emitted for every locale **including the current one**. Reciprocity is what makes the cluster credible.
 - `og:locale` needs `language_TERRITORY` (`fr_FR`), from `ogLocales`. hreflang uses the bare code, so the two differ on purpose.
 - `source/sitemap.blade.xml` builds the sitemap by walking `routes` and `locales`, with `xhtml:link` hreflang annotations. It is named `.blade.xml` so Jigsaw writes `sitemap.xml` rather than `sitemap.html`. Its XML declaration is echoed as a string, because a literal `<?xml` would be parsed as a PHP open tag.
+- **`lastmod` is hand-kept, never the build date.** Three sources, one per family of URL: an ordinary page reads the `lastmod` map in `config.php` (via `$page->lastmodFor($key)`, which throws on a key with no entry), a post reads `$post->lastmodDate()`, and a page of the blog index reads the newest post it lists. Nothing derives it from a file's mtime or from the deploy, because a sitemap that claims every page changed on every deploy teaches a crawler to ignore the field. Move a date when the copy changes in a way a reader would notice, not for a refactor behind identical text.
 - `source/index.blade.php` and `source/404.blade.php` both set an explicit `permalink`, because pretty URLs would otherwise write them to `index/index.html` and `404/index.html`. Both carry `noindex`, and neither is in the sitemap.
 
 Social cards are `source/og/monica-<locale>.png`, one per language, 1200x630. They are generated from `scripts/og/template.html` by `npm run og`, which drives headless Chrome. The PNGs are committed so a build never depends on a browser being installed. **The template mirrors the hero copy by hand**, so when a hero headline changes in `lang/`, update the template and re-run `npm run og`.
@@ -211,13 +213,15 @@ The homepage, the three features pages, pricing, the v3 teaser, the team page, t
 
 **Dates are timestamps.** YAML reads an unquoted `date: 2018-10-12` as a date and hands it back as ten digits, so anything that displays a date or gives one to a crawler calls `$post->isoDate()`. `readingMinutes()` and `authorInitials()` are collection helpers alongside it.
 
+**`updated` is the one fact about a post that may differ between languages.** It is optional front matter, it feeds `$post->lastmodDate()` and through it the sitemap's `lastmod`, and it falls back to `date` because a post nobody has touched was last modified when it was published. Per locale on purpose: the slug and the date are the same fact in five files, but a French translation corrected on its own should say so without moving the other four. Set it only for a change a reader would notice.
+
 `.mn-prose` in `source/_assets/css/prose.css` styles the rendered Markdown. It is the one place on the site that styles by element rather than by class, because the markup is generated and there is nothing to hang a utility on. Nothing else belongs in that file.
 
 **The feed** is RSS 2.0 at `/<locale>/blog/feed.xml`, the 20 newest posts with their full bodies. `feedContent()` rewrites every `src` and `href` to an absolute URL first, because a feed is read on someone else's host and root-relative markup resolves against that host instead of ours. `rfcDate()` exists because RSS accepts only RFC 2822 dates. `lastBuildDate` is the newest post's date rather than the build's, so rebuilding the site does not tell every reader the feed changed.
 
 Autodiscovery (`rel="alternate" type="application/rss+xml"`) is in `_layouts/base.blade.php`, so it is on every page rather than only the blog: the page someone is on when they decide to subscribe is rarely the index. It points at the current locale's feed. That is safe under Turbo for the same reason `<html lang>` is: the link is identical across a locale, and crossing locales is a full page load because the locale picker carries `data-turbo="false"`.
 
-Posts have no categories: the two the old site used were dropped on import. Adding a post means a Markdown file in **every** `source/_posts_<locale>/` with `title`, `slug`, `date`, `author` and `description`, and nothing else to register. The same slug and the same date in all five, the title, the description and the body translated. A post present in one language and missing in another fails the dead-link check, because the sitemap lists it for every locale.
+Posts have no categories: the two the old site used were dropped on import. Adding a post means a Markdown file in **every** `source/_posts_<locale>/` with `title`, `slug`, `date`, `author` and `description` (plus `updated` once it has been changed), and nothing else to register. The same slug and the same date in all five, the title, the description and the body translated. A post present in one language and missing in another fails the dead-link check, because the sitemap lists it for every locale.
 
 See the [collections docs](https://jigsaw.tighten.com/docs/collections/).
 

--- a/config.php
+++ b/config.php
@@ -27,6 +27,17 @@ $perPage = 10;
 $perFeed = 20;
 
 /**
+ * A front-matter date as the ISO string a crawler wants.
+ *
+ * YAML reads an unquoted `date: 2018-10-12` as a date and hands it over as a
+ * Unix timestamp; a quoted one stays a string. Both shapes arrive here, and
+ * both leave as Y-m-d.
+ */
+$isoDay = fn ($value) => is_numeric($value)
+    ? date('Y-m-d', (int) $value)
+    : (string) $value;
+
+/**
  * Everything a posts collection is, apart from where it reads and where it
  * writes. Shared by all five, so a change to the sort order or to a helper
  * cannot land in one language and miss the other four.
@@ -82,10 +93,28 @@ $postSettings = [
      * metadata, it reads the same in every language, and it is the
      * one fact on the page a reader may want to compare or copy.
      */
-    'isoDate' => function ($post) {
-        return is_numeric($post->date)
-            ? date('Y-m-d', (int) $post->date)
-            : (string) $post->date;
+    'isoDate' => function ($post) use ($isoDay) {
+        return $isoDay($post->date);
+    },
+
+    /**
+     * When this post was last meaningfully changed, for the sitemap's lastmod.
+     *
+     * `updated` in the front matter when a post has been corrected, rewritten
+     * or retranslated, the publication date otherwise, because a post nobody
+     * has touched was last modified when it was published.
+     *
+     * Read per locale rather than per slug, so a French translation fixed on
+     * its own says so and the four other languages keep the date they had.
+     * That is the only reason `updated` is front matter and not a shared fact
+     * like the slug: it is the one thing about a post that legitimately
+     * differs between the five files.
+     *
+     * Only set it for a change a reader would notice. A typo fixed in a
+     * heading is not a reason to tell every crawler the article is new.
+     */
+    'lastmodDate' => function ($post) use ($isoDay) {
+        return $post->updated ? $isoDay($post->updated) : $post->isoDate();
     },
 
     /** The same date as RFC 2822, which is the only format RSS accepts. */
@@ -275,6 +304,39 @@ return [
         ],
     ],
 
+    // ---------------------------------------------------------------- lastmod
+
+    /**
+     * When each page was last meaningfully changed, for the sitemap.
+     *
+     * A crawler treats lastmod as a hint about whether re-fetching a URL is
+     * worth its time, and it only stays a useful hint while it is true. So this
+     * is a hand-kept fact rather than the build date or the file's mtime: both
+     * of those say "everything changed" every time anything is deployed, which
+     * teaches a crawler to ignore the field entirely.
+     *
+     * One date per page, not per locale. The copy for all five lives in the
+     * same `lang/` edit, so they change together.
+     *
+     * Update the entry when the page's copy changes in a way a reader would
+     * notice. A CSS tweak or a refactor behind identical text is not one.
+     *
+     * Every key in `routes` needs an entry here, except `blog`: the index's
+     * lastmod is the newest post it lists, which the sitemap works out from the
+     * archive rather than from a number somebody has to remember.
+     */
+    'lastmod' => [
+        'home' => '2026-08-06',
+        'v3' => '2026-08-06',
+        'pricing' => '2026-08-06',
+        'features' => '2026-08-06',
+        'featuresDashboard' => '2026-08-06',
+        'featuresJournal' => '2026-08-06',
+        'terms' => '2026-08-06',
+        'team' => '2026-08-06',
+        'privacy' => '2026-08-06',
+    ],
+
     // ------------------------------------------------------------------ links
 
     /**
@@ -434,6 +496,25 @@ return [
         }
 
         return $page->localePath($page->page, $locale);
+    },
+
+    /**
+     * When the page behind a route key was last changed: `$page->lastmodFor('pricing')`.
+     *
+     * Throws on a key with no entry, the same way `t()` throws on a missing
+     * translation, because a page added to `routes` and forgotten here would
+     * otherwise drop out of the sitemap's lastmod silently. A build that fails
+     * naming the key is a one-line fix; a sitemap quietly missing a date is not
+     * something anybody goes looking for.
+     */
+    'lastmodFor' => function ($page, string $key) {
+        $date = $page->lastmod[$key] ?? null;
+
+        if ($date === null) {
+            throw new Exception("Missing lastmod for page [{$key}]. Add it to the 'lastmod' map in config.php.");
+        }
+
+        return $date;
     },
 
     /**

--- a/source/sitemap.blade.xml
+++ b/source/sitemap.blade.xml
@@ -13,13 +13,31 @@
       - the blog index, once per page of the list per locale
       - the posts, one per post per locale
 
+    Each carries a lastmod, and each family knows its own: an ordinary page
+    reads the hand-kept map in config.php, a post reads its own front matter,
+    and a page of the index reads the newest post it lists. Both the path and
+    the date are resolved per locale, so a translation corrected on its own
+    says so without moving the other four.
+
     Named .blade.xml so Jigsaw writes sitemap.xml rather than sitemap.html.
 --}}
 @php
-    $urls = [];
+    $entries = [];
 
+    // The blog index is the exception in this loop: it paginates, and its
+    // lastmod comes from the posts rather than from the map, so it is built
+    // below alongside them.
     foreach (collect($page->routes)->keys() as $key) {
-        $urls[] = fn ($locale) => $page->localePath($key, $locale);
+        if ($key === 'blog') {
+            continue;
+        }
+
+        $lastmod = $page->lastmodFor($key);
+
+        $entries[] = [
+            'path' => fn ($locale) => $page->localePath($key, $locale),
+            'lastmod' => fn ($locale) => $lastmod,
+        ];
     }
 
     // The English archive is the list of slugs, because a post carries the same
@@ -29,30 +47,62 @@
     // dropped from that language's sitemap.
     $posts = $posts_en;
 
+    // Every locale's archive, keyed by slug, so a URL's lastmod is the one that
+    // locale's own file declares. Newest first already, from the shared
+    // collection settings, which is what makes the slice below a page of the
+    // index rather than an arbitrary ten posts.
+    $archives = [];
+
+    foreach ($page->locales as $locale) {
+        $archives[$locale] = collect(${'posts_' . $locale})->keyBy('slug');
+    }
+
     // ceil rather than a stored count: the paginator is the only thing that
     // knows how many pages there are, and it is not running here.
     $pages = (int) ceil($posts->count() / $page->postsPerPage);
 
-    for ($number = 2; $number <= $pages; $number++) {
-        $urls[] = fn ($locale) => $page->blogPath($locale, $number);
+    for ($number = 1; $number <= $pages; $number++) {
+        $entries[] = [
+            'path' => fn ($locale) => $page->blogPath($locale, $number),
+
+            // The newest thing on this page of the list. Page 1 moves whenever
+            // a post is published; the last page has not changed since 2017 and
+            // now says so, which is the whole point of the field.
+            'lastmod' => fn ($locale) => $archives[$locale]
+                ->slice(($number - 1) * $page->postsPerPage, $page->postsPerPage)
+                ->map(fn ($post) => $post->lastmodDate())
+                ->max(),
+        ];
     }
 
     foreach ($posts as $post) {
-        $urls[] = fn ($locale) => $page->postPath($post->slug, $locale);
+        $slug = $post->slug;
+
+        $entries[] = [
+            'path' => fn ($locale) => $page->postPath($slug, $locale),
+
+            // Falls back to the English post when a locale has not got this one
+            // yet. Nothing is hidden by that: the URL is still listed, so the
+            // dead-link checker still fails the build on the page that was never
+            // written. It only keeps the failure legible instead of a method
+            // call on null several hundred files away from the missing one.
+            'lastmod' => fn ($locale) => ($archives[$locale]->get($slug) ?: $post)->lastmodDate(),
+        ];
     }
 @endphp
 {{-- The XML declaration is echoed, because a literal <?xml would be parsed
      as a PHP open tag. --}}
 {!! '<'.'?xml version="1.0" encoding="UTF-8"?'.'>' !!}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
-@foreach ($urls as $url)
+@foreach ($entries as $entry)
 @foreach ($page->locales as $locale)
     <url>
-        <loc>{{ $page->absolute($url($locale)) }}</loc>
+        <loc>{{ $page->absolute($entry['path']($locale)) }}</loc>
+        <lastmod>{{ $entry['lastmod']($locale) }}</lastmod>
 @foreach ($page->locales as $alternate)
-        <xhtml:link rel="alternate" hreflang="{{ $alternate }}" href="{{ $page->absolute($url($alternate)) }}"/>
+        <xhtml:link rel="alternate" hreflang="{{ $alternate }}" href="{{ $page->absolute($entry['path']($alternate)) }}"/>
 @endforeach
-        <xhtml:link rel="alternate" hreflang="x-default" href="{{ $page->absolute($url($page->defaultLocale)) }}"/>
+        <xhtml:link rel="alternate" hreflang="x-default" href="{{ $page->absolute($entry['path']($page->defaultLocale)) }}"/>
     </url>
 @endforeach
 @endforeach


### PR DESCRIPTION
Closes #26.

Every `<url>` in the sitemap carried a `<loc>` and its hreflang cluster, and no `<lastmod>` at all. A crawler uses that field to decide whether re-fetching a URL is worth its time, so a sitemap without it asks to have all 260 URLs treated the same way, and a 2017 release note gets re-crawled as often as the pricing page.

The date is hand-kept rather than derived from the build or from a file's mtime. Both of those say "everything changed" on every deploy, which teaches a crawler to ignore the field entirely.

Three families of URL, each with its own source:

- **Ordinary pages** read a `lastmod` map in `config.php`, keyed by route key, through `$page->lastmodFor()`. It throws on a key with no entry, the same way `t()` throws on a missing translation, so a page added to `routes` and forgotten here fails the build instead of quietly losing its date. Every entry is seeded at `2026-08-06`, which is where the content stands today.
- **Posts** read an optional `updated:` field in their front matter, falling back to `date`, because a post nobody has touched was last modified when it was published. `updated` is per locale on purpose: the slug and the date are the same fact in all five files, but a translation corrected on its own should say so without moving the other four.
- **Pages of the blog index** read the newest post they list. Page 1 moves whenever a post is published; the last page has not changed since 2017 and now says so.

Notes:

- The blog index is no longer emitted from the `routes` loop, so page 1 comes from the same code path as pages 2 to 4 and gets the same date. The sitemap still lists exactly 260 URLs.
- `isoDate()` and `lastmodDate()` share one date-normalising closure, since YAML hands back an unquoted date as a Unix timestamp and a quoted one as a string.
- Adding a page now has a fourth step, recorded in `.claude/CLAUDE.md`.