### PR TITLE
feat(links): point 'Get started' at the app's register page

### DIFF
--- a/config.php
+++ b/config.php
@@ -413,7 +413,7 @@ return [
     'links' => [
         'github' => 'https://github.com/monicahq/monica',
         'signIn' => 'https://app.monicahq.com',
-        'getStarted' => '#',
+        'getStarted' => 'https://app.monicahq.com/register',
         'createAccount' => '#',
         'selfHost' => '#',
         'selfHostingGuide' => '#',


### PR DESCRIPTION
## What

`links.getStarted` in `config.php` was still the `#` placeholder carried over from the design. It now points at `https://app.monicahq.com/register`.

## Why

The "Get started" button in the header had no destination. That key is read by six call sites (header, homepage hero, homepage final CTA, pricing plans, pricing final CTA, the blog's "try Monica" card), so filling it in gives every "Get started" the same real destination rather than leaving five of them dead.

`links.createAccount`, `selfHost`, `selfHostingGuide`, `docs` and `api` are untouched and still placeholders.

## Checks

`npm run build` passes. The dead-link report no longer lists `links.getStarted`, and `build_production/en/index.html` carries three `href="https://app.monicahq.com/register"`, one per call site on that page.