### PR TITLE
feat(blog): announce the new version of Monica for 2026

### DIFF
--- a/source/_posts_de/2026-08-06-new-version-of-monica-in-2026.md
+++ b/source/_posts_de/2026-08-06-new-version-of-monica-in-2026.md
@@ -1,0 +1,24 @@
+---
+title: "Eine neue Version von Monica kommt 2026"
+slug: new-version-of-monica-in-2026
+date: 2026-08-06
+author: 'Regis Freyd'
+description: "Wir bringen die neue Version von Monica noch vor Ende 2026 heraus."
+---
+Es ist eine Weile her, dass wir uns richtig zu Monica gemeldet haben.
+
+Alexis und ich denken schon sehr lange über eine neue Version nach. Länger, als wir ursprünglich erwartet hatten, natürlich. Eine Anwendung von Grund auf neu zu bauen, während man einen Vollzeitjob, eine Familie und ein Leben außerhalb von Monica hat, dauert eben doch etwas. Wer hätte das gedacht.
+
+Heute können wir aber endlich sagen: Wir bringen die neue Version von Monica noch vor Ende 2026 heraus.
+
+Diese neue Version ist das Monica, das wir seit Jahren bauen wollten. Sie wird schneller sein, flexibler, einfacher zu bedienen und auf einem viel stabileren Fundament stehen.
+
+Monica hilft Ihnen weiterhin dabei, sich an die Menschen zu erinnern, die Ihnen wichtig sind. Sie bleibt privat. Sie bleibt quelloffen. Und Sie können sie weiterhin kostenlos auf Ihrem eigenen Server installieren.
+
+Wir freuen uns unglaublich darauf. Monica gehört seit fast zehn Jahren zu unserem Leben, und das hier fühlt sich wie der Anfang eines völlig neuen Kapitels für das Projekt an.
+
+Es gibt noch viel zu tun.
+
+Aber es kommt. Diesmal wirklich.
+
+Danke für Ihre Geduld, Ihre Nachrichten und Ihre Unterstützung in all den Jahren. Wir können es kaum erwarten, Ihnen zu zeigen, was wir gebaut haben.

--- a/source/_posts_en/2026-08-06-new-version-of-monica-in-2026.md
+++ b/source/_posts_en/2026-08-06-new-version-of-monica-in-2026.md
@@ -1,0 +1,24 @@
+---
+title: 'A new version of Monica is coming in 2026'
+slug: new-version-of-monica-in-2026
+date: 2026-08-06
+author: 'Regis Freyd'
+description: 'We will launch the new version of Monica before the end of 2026.'
+---
+It's been a while since we gave a proper update about Monica.
+
+Alexis and I have been thinking about a new version for a very long time. Longer than we initially expected, obviously. Rebuilding an application from scratch while having full-time jobs, families and lives outside of Monica turns out to take a bit of time. Who knew?
+
+But today, we can finally say this: we will launch the new version of Monica before the end of 2026.
+
+This new version is the Monica we've wanted to build for years. It will be faster, more flexible, easier to use and built on a much stronger foundation.
+
+Monica will still help you remember the people who matter to you. It will still be private. It will still be open source. And you will still be able to install it on your own server for free.
+
+We're incredibly excited. Monica has been part of our lives for almost ten years now, and this feels like the beginning of a completely new chapter for the project.
+
+There is a lot of work to do.
+
+But it's coming. For real this time.
+
+Thank you for your patience, your messages and your support over all these years. We can't wait to show you what we've built.

--- a/source/_posts_es/2026-08-06-new-version-of-monica-in-2026.md
+++ b/source/_posts_es/2026-08-06-new-version-of-monica-in-2026.md
@@ -1,0 +1,24 @@
+---
+title: "Una nueva versión de Monica llega en 2026"
+slug: new-version-of-monica-in-2026
+date: 2026-08-06
+author: 'Regis Freyd'
+description: "Lanzaremos la nueva versión de Monica antes de que acabe 2026."
+---
+Hace tiempo que no dábamos noticias serias sobre Monica.
+
+Alexis y yo llevamos muchísimo tiempo pensando en una nueva versión. Más tiempo del que esperábamos al principio, claro. Reconstruir una aplicación desde cero mientras tienes un trabajo a tiempo completo, una familia y una vida fuera de Monica resulta que lleva su tiempo. Quién lo iba a decir.
+
+Pero hoy por fin podemos decirlo: lanzaremos la nueva versión de Monica antes de que acabe 2026.
+
+Esta nueva versión es la Monica que queríamos construir desde hace años. Será más rápida, más flexible, más fácil de usar y estará levantada sobre unos cimientos mucho más sólidos.
+
+Monica seguirá ayudándote a recordar a las personas que te importan. Seguirá siendo privada. Seguirá siendo de código abierto. Y seguirás pudiendo instalarla gratis en tu propio servidor.
+
+Estamos entusiasmados. Monica lleva casi diez años formando parte de nuestras vidas, y esto se siente como el comienzo de un capítulo completamente nuevo para el proyecto.
+
+Queda mucho trabajo por hacer.
+
+Pero llega. Esta vez de verdad.
+
+Gracias por vuestra paciencia, vuestros mensajes y vuestro apoyo durante todos estos años. Estamos deseando enseñaros lo que hemos construido.

--- a/source/_posts_fr/2026-08-06-new-version-of-monica-in-2026.md
+++ b/source/_posts_fr/2026-08-06-new-version-of-monica-in-2026.md
@@ -1,0 +1,24 @@
+---
+title: "Une nouvelle version de Monica arrive en 2026"
+slug: new-version-of-monica-in-2026
+date: 2026-08-06
+author: 'Regis Freyd'
+description: "Nous lancerons la nouvelle version de Monica avant la fin de 2026."
+---
+Cela fait un moment que nous n'avons pas donné de vraies nouvelles de Monica.
+
+Alexis et moi réfléchissons à une nouvelle version depuis très longtemps. Plus longtemps que prévu, évidemment. Reconstruire une application de zéro quand on a un emploi à plein temps, une famille et une vie en dehors de Monica prend un peu de temps, il faut croire.
+
+Mais aujourd'hui, nous pouvons enfin le dire : nous lancerons la nouvelle version de Monica avant la fin de 2026.
+
+Cette nouvelle version, c'est la Monica que nous voulions construire depuis des années. Elle sera plus rapide, plus souple, plus simple à utiliser, et bâtie sur des fondations bien plus solides.
+
+Monica vous aidera toujours à vous souvenir des personnes qui comptent pour vous. Elle restera privée. Elle restera open source. Et vous pourrez toujours l'installer gratuitement sur votre propre serveur.
+
+Nous sommes incroyablement enthousiastes. Monica fait partie de nos vies depuis presque dix ans, et nous avons le sentiment d'ouvrir un tout nouveau chapitre pour le projet.
+
+Il reste beaucoup de travail.
+
+Mais ça arrive. Pour de vrai cette fois.
+
+Merci pour votre patience, vos messages et votre soutien pendant toutes ces années. Nous avons hâte de vous montrer ce que nous avons construit.

--- a/source/_posts_pt/2026-08-06-new-version-of-monica-in-2026.md
+++ b/source/_posts_pt/2026-08-06-new-version-of-monica-in-2026.md
@@ -1,0 +1,24 @@
+---
+title: "Uma nova versão do Monica chega em 2026"
+slug: new-version-of-monica-in-2026
+date: 2026-08-06
+author: 'Regis Freyd'
+description: "Vamos lançar a nova versão do Monica antes do fim de 2026."
+---
+Já faz um tempo que não damos notícias de verdade sobre o Monica.
+
+Alexis e eu pensamos numa nova versão há muito tempo. Mais tempo do que esperávamos no início, claro. Reconstruir uma aplicação do zero tendo empregos em tempo integral, famílias e uma vida fora do Monica leva um certo tempo. Quem diria.
+
+Mas hoje podemos finalmente dizer: vamos lançar a nova versão do Monica antes do fim de 2026.
+
+Esta nova versão é o Monica que queríamos construir há anos. Será mais rápido, mais flexível, mais fácil de usar e assentado numa base muito mais sólida.
+
+O Monica vai continuar ajudando você a lembrar das pessoas que importam para você. Vai continuar privado. Vai continuar de código aberto. E você vai continuar podendo instalá-lo de graça no seu próprio servidor.
+
+Estamos muito animados. O Monica faz parte das nossas vidas há quase dez anos, e isto parece o começo de um capítulo completamente novo para o projeto.
+
+Há muito trabalho pela frente.
+
+Mas está chegando. Desta vez de verdade.
+
+Obrigado pela sua paciência, pelas suas mensagens e pelo seu apoio ao longo de todos estes anos. Mal podemos esperar para mostrar o que construímos.


### PR DESCRIPTION
Adds a blog post announcing that the new version of Monica ships before the end of 2026.

- adds `2026-08-06-new-version-of-monica-in-2026.md` to all five post collections (`en`, `fr`, `de`, `es`, `pt`)
- the slug, the date and the author are identical in the five files; the title, the description and the body are translated

Notes:

- the post is text only, so nothing was added to `source/assets/images/blog/`
- being the newest post, it now heads every locale's blog index and feed, and it appears in the sitemap for the five locales